### PR TITLE
Link against PTYHON_LIBRARIES

### DIFF
--- a/cv_bridge/src/CMakeLists.txt
+++ b/cv_bridge/src/CMakeLists.txt
@@ -20,6 +20,7 @@ include_directories(SYSTEM ${PYTHON_INCLUDE_PATH}
 add_library(${PROJECT_NAME}_boost module.cpp)
 target_link_libraries(${PROJECT_NAME}_boost ${Boost_LIBRARIES}
                                             ${catkin_LIBRARIES}
+                                            ${PYTHON_LIBRARIES}
                                             ${PROJECT_NAME}
 )
 


### PR DESCRIPTION
When building on OS X:

```
==> Processing catkin package: 'cv_bridge'
==> Building with env: '/Users/william/ros_catkin_ws/install_isolated/env.sh'
Makefile exists, skipping explicit cmake invocation...
==> make cmake_check_build_system in '/Users/william/ros_catkin_ws/build_isolated/cv_bridge'
==> make -j4 in '/Users/william/ros_catkin_ws/build_isolated/cv_bridge'
Linking CXX shared library /Users/william/ros_catkin_ws/devel_isolated/cv_bridge/lib/libcv_bridge.dylib
ld: warning: directory not found for option '-L/Users/william/ros_catkin_ws/install_isolated/share/OpenCV/3rdparty/lib'
[ 50%] Built target cv_bridge
Linking CXX shared library /Users/william/ros_catkin_ws/devel_isolated/cv_bridge/lib/python2.7/site-packages/cv_bridge/boost/cv_bridge_boost.dylib
ld: warning: directory not found for option '-L/Users/william/ros_catkin_ws/install_isolated/share/OpenCV/3rdparty/lib'
Undefined symbols for architecture x86_64:
  "_PyErr_SetString", referenced from:
      __ZL7failmsgPKcz in module.cpp.o
  "_PyExc_TypeError", referenced from:
      __ZL7failmsgPKcz in module.cpp.o
  "_PyImport_ImportModule", referenced from:
      init_module_cv_bridge_boost() in module.cpp.o
  "_PyInt_FromLong", referenced from:
      boost::python::to_python_value<int const&>::operator()(int const&) const in module.cpp.o
  "_PyInt_Type", referenced from:
      boost::python::to_python_value<int const&>::get_pytype() const in module.cpp.o
  "_PyObject_AsWriteBuffer", referenced from:
      __ZL16convert_to_CvMatP7_objectPP5CvMatPKc in module.cpp.o
  "_PyObject_CallObject", referenced from:
      __ZL10FROM_CvMatP5CvMat in module.cpp.o
  "_PyObject_GetAttrString", referenced from:
      __ZL10FROM_CvMatP5CvMat in module.cpp.o
  "_PyString_AsString", referenced from:
      __ZL16convert_to_CvMatP7_objectPP5CvMatPKc in module.cpp.o
  "_Py_BuildValue", referenced from:
      __ZL10FROM_CvMatP5CvMat in module.cpp.o
  "__Py_NoneStruct", referenced from:
      boost::python::api::object::object() in module.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [/Users/william/ros_catkin_ws/devel_isolated/cv_bridge/lib/python2.7/site-packages/cv_bridge/boost/cv_bridge_boost.dylib] Error 1
make[1]: *** [src/CMakeFiles/cv_bridge_boost.dir/all] Error 2
make: *** [all] Error 2
<== Failed to process package 'cv_bridge': 
  KeyboardInterrupt
Command failed, exiting.
```

It's just missing a link against Python libs.

ROS Answers:

http://answers.ros.org/question/52341/building-cv_bridge-with-catkin-fails/?comment=52428#comment-52428
