### PR TITLE
Add dependency on generated messages

### DIFF
--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -20,6 +20,7 @@ include_directories(include)
 # add a library
 add_library(${PROJECT_NAME} src/pinhole_camera_model.cpp src/stereo_camera_model.cpp)
 target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES})
+add_dependencies(${PROJECT_NAME} sensor_msgs_gencpp)
 
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/


### PR DESCRIPTION
Catkin requires explicit enumeration of dependencies on generated messages.
Add this declaration to properly flatten the dependency graph and force Catkin
to generate geometry_msgs before compiling image_geometry.
