### PR TITLE
check for CATKIN_ENABLE_TESTING

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -21,7 +21,9 @@ link_directories(${OpenCV_LIB_DIR})
 
 add_subdirectory(python)
 add_subdirectory(src)
-add_subdirectory(test)
+if(CATKIN_ENABLE_TESTING)
+  add_subdirectory(test)
+endif()
 
 # install the include folder
 install(

--- a/cv_bridge/package.xml
+++ b/cv_bridge/package.xml
@@ -17,7 +17,7 @@
     <rosdoc config="rosdoc.yaml" />
   </export>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>boost</build_depend>
   <build_depend>opencv2</build_depend>

--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -33,4 +33,6 @@ install(TARGETS ${PROJECT_NAME}
 )
 
 # add tests
-add_subdirectory(test)
+if(CAKTIN_ENABLE_TESTING)
+  add_subdirectory(test)
+endif()

--- a/image_geometry/package.xml
+++ b/image_geometry/package.xml
@@ -16,7 +16,7 @@
     <rosdoc config="rosdoc.yaml" />
   </export>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>opencv2</build_depend>
   <build_depend>sensor_msgs</build_depend>


### PR DESCRIPTION
Since version 0.5.68, catkin provides to optionally configure tests. This commit adjusts the CMakeLists.txt to opt-in the tests.
