### PR TITLE
Find NumPy include directory

### DIFF
--- a/cv_bridge/src/CMakeLists.txt
+++ b/cv_bridge/src/CMakeLists.txt
@@ -7,10 +7,27 @@ install(TARGETS ${PROJECT_NAME} DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 # add a Boost Python library
 set(Python_ADDITIONAL_VERSIONS 2.7)
+find_package(PythonInterp REQUIRED)
 find_package(PythonLibs REQUIRED)
+
+#Get the numpy include directory from its python module
+if(NOT PYTHON_NUMPY_INCLUDE_DIR)
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import numpy; print numpy.get_include()"
+                    RESULT_VARIABLE PYTHON_NUMPY_PROCESS
+                    OUTPUT_VARIABLE PYTHON_NUMPY_INCLUDE_DIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(PYTHON_NUMPY_PROCESS EQUAL 0)
+       file(TO_CMAKE_PATH "${PYTHON_NUMPY_INCLUDE_DIR}" PYTHON_NUMPY_INCLUDE_CMAKE_PATH)
+       set(PYTHON_NUMPY_INCLUDE_DIR ${PYTHON_NUMPY_INCLUDE_CMAKE_PATH} CACHE PATH "Numpy include directory")
+    else(PYTHON_NUMPY_PROCESS EQUAL 0)
+        message(SEND_ERROR "Could not determine the NumPy include directory, verify that NumPy was installed correctly.")
+    endif(PYTHON_NUMPY_PROCESS EQUAL 0)
+ endif(NOT PYTHON_NUMPY_INCLUDE_DIR)
 
 include_directories(SYSTEM ${PYTHON_INCLUDE_PATH}
                            ${Boost_INCLUDE_DIRS}
+                           ${PYTHON_NUMPY_INCLUDE_DIR} # cv_bridge module uses NumPy functions
 )
 
 add_library(${PROJECT_NAME}_boost module.cpp)


### PR DESCRIPTION
The NumPy include directories are not set, causing build errors on OS X. I noticed this already while doing my previous pull request, but thought it was related to a misconfiguration on my system. Really I don't know how this builds on Ubuntu, the devs must place the NumPy headers inside of the Python include directory.
