### PR TITLE
Added operator= for the PinholeCameraModel.

### DIFF
--- a/image_geometry/include/image_geometry/pinhole_camera_model.h
+++ b/image_geometry/include/image_geometry/pinhole_camera_model.h
@@ -27,6 +27,8 @@ public:
 
   PinholeCameraModel(const PinholeCameraModel& other);
 
+  PinholeCameraModel& operator=(const PinholeCameraModel& other);
+
   /**
    * \brief Set the camera parameters from the sensor_msgs/CameraInfo message.
    */

--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -33,6 +33,13 @@ PinholeCameraModel::PinholeCameraModel()
 {
 }
 
+PinholeCameraModel& PinholeCameraModel::operator=(const PinholeCameraModel& other)
+{
+  if (other.initialized())
+    this->fromCameraInfo(other.cameraInfo());
+  return *this;
+}
+
 PinholeCameraModel::PinholeCameraModel(const PinholeCameraModel& other)
 {
   if (other.initialized())


### PR DESCRIPTION
Added the operator= for the PinholeCameraModel. I am not sure if the
PinholeCameraModel needs to have a destructor, too. To follow the
'rule of three' it should actually have one.

[1] http://answers.ros.org/question/118911/image_geometrypinholecameramodel-operator-missing/
