### PR TITLE
fixed Python rectifyImage implementation in PinholeCameraModel

### DIFF
--- a/image_geometry/src/image_geometry/cameramodels.py
+++ b/image_geometry/src/image_geometry/cameramodels.py
@@ -82,7 +82,7 @@ class PinholeCameraModel:
 
         self.mapx = cv.CreateImage((self.width, self.height), cv.IPL_DEPTH_32F, 1)
         self.mapy = cv.CreateImage((self.width, self.height), cv.IPL_DEPTH_32F, 1)
-        cv.InitUndistortMap(self.K, self.D, self.mapx, self.mapy)
+        cv.InitUndistortRectifyMap(self.K, self.D, self.R, self.P, self.mapx, self.mapy)
         cv.Remap(raw, rectified, self.mapx, self.mapy)
         
     def rectifyPoint(self, uv_raw):


### PR DESCRIPTION
The implementation of rectifyImage(...) method of PinholeCameraModel in Python was not equivalent to the C++ one. As it was based on InitUndistortMap(...) function of OpenCV, it only undistorted the image without using the rotation and the new camera matrix specified in the camera model. I changed it with the InitUndistortRectifyMap(...) function of OpenCV which considers also these transformations.
