### PR TITLE
Add depend on python for cv_bridge

### DIFF
--- a/cv_bridge/package.xml
+++ b/cv_bridge/package.xml
@@ -21,12 +21,14 @@
 
   <build_depend>boost</build_depend>
   <build_depend>libopencv-dev</build_depend>
+  <build_depend>python</build_depend>
   <build_depend>python-opencv</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
   <run_depend>boost</run_depend>
   <run_depend>libopencv-dev</run_depend>
+  <run_depend>python</run_depend>
   <run_depend>python-opencv</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>sensor_msgs</run_depend>


### PR DESCRIPTION
The python headers must be installed because of https://github.com/ros-perception/vision_opencv/blob/indigo/cv_bridge/src/CMakeLists.txt#L10

The `rosdep` key `python` installs the python headers: https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml#L48-L68

I'm not sure why this isn't a problem for Ubuntu.
