### PR TITLE
pinhole_camera_model: fix implicit shared_ptr cast to bool for C++11

### DIFF
--- a/image_geometry/include/image_geometry/pinhole_camera_model.h
+++ b/image_geometry/include/image_geometry/pinhole_camera_model.h
@@ -257,7 +257,7 @@ public:
   /**
    * \brief Returns true if the camera has been initialized
    */
-  bool initialized() const { return cache_; }
+  bool initialized() const { return (bool)cache_; }
 
 protected:
   sensor_msgs::CameraInfo cam_info_;


### PR DESCRIPTION
In C++11 boost::shared_ptr does not provide the implicit bool conversion
operator anymore, so make the cast in pinhole_camera_model.h explicit.
That does not hurt in older C++ standards and makes compilation with C++11
possible.
