### PR TITLE
fixes #62, bug in Python rectifyPoint old opencv1 API

### DIFF
--- a/image_geometry/src/image_geometry/cameramodels.py
+++ b/image_geometry/src/image_geometry/cameramodels.py
@@ -100,9 +100,8 @@ class PinholeCameraModel:
         """
 
         src = mkmat(1, 2, list(uv_raw))
-        src.resize((2, 1))
-        dst = src.copy()
-        cv2.undistortPoints(src, dst, self.K, self.D, self.R, self.P)
+        src.resize((1,1,2))
+        dst = cv2.undistortPoints(src, self.K, self.D, R=self.R, P=self.P)
         return dst[0,0]
 
     def project3dToPixel(self, point):

--- a/image_geometry/test/directed.py
+++ b/image_geometry/test/directed.py
@@ -20,7 +20,7 @@ class TestDirected(unittest.TestCase):
         print ci
         cam = PinholeCameraModel()
         cam.fromCameraInfo(ci)
-        #print cam.rectifyPoint((0, 0))
+        print cam.rectifyPoint((0, 0))
 
         print cam.project3dToPixel((0,0,0))
 


### PR DESCRIPTION
the ["test"](https://github.com/ros-perception/vision_opencv/blob/indigo/image_geometry/test/directed.py#L23) now runs successfully (i.e. doesn't crash). I also tried some arbitrary values from my own camera calibration and the resulting values did not seem insane (I did not precisely measure them, but this bug fix really only has to do with API change).

EDIT:
note that you have to uncomment line 23 from the `directed.py` test in order for this bug to show (this PR fixes it). Check #62 for more details.
