### PR TITLE
fix image output of fback_flow

### DIFF
--- a/opencv_apps/src/nodelet/fback_flow_nodelet.cpp
+++ b/opencv_apps/src/nodelet/fback_flow_nodelet.cpp
@@ -166,7 +166,7 @@ class FBackFlowNodelet : public nodelet::Nodelet
 
 
       // Publish the image.
-      sensor_msgs::Image::Ptr out_img = cv_bridge::CvImage(msg->header, msg->encoding,frame).toImageMsg();
+      sensor_msgs::Image::Ptr out_img = cv_bridge::CvImage(msg->header, msg->encoding, cflow).toImageMsg();
       img_pub_.publish(out_img);
       msg_pub_.publish(flows_msg);
     }


### PR DESCRIPTION
Now this will show the result of flow calculation instead of frame image.
![fback_flow](https://cloud.githubusercontent.com/assets/3803922/8644159/d44992ea-2977-11e5-93ac-027cf7419dc3.png)
