### PR TITLE
Added conversion support for kinect depth images.

### DIFF
--- a/cv_bridge/include/cv_bridge/cv_bridge.h
+++ b/cv_bridge/include/cv_bridge/cv_bridge.h
@@ -38,8 +38,11 @@
 
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/CompressedImage.h>
+#include <sensor_msgs/image_encodings.h>
 #include <ros/static_assert.h>
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/imgproc/types_c.h>
 #include <stdexcept>
 
 namespace cv_bridge {
@@ -186,6 +189,30 @@ CvImagePtr toCvCopy(const sensor_msgs::Image& source,
 
 CvImagePtr toCvCopy(const sensor_msgs::CompressedImage& source,
                     const std::string& encoding = std::string());
+
+/**
+ * \brief Convert a sensor_msgs::Image message to an OpenCV-compatible CvImage.
+ * Supports both color and depth Kinect image formats.
+ *
+ * \param source   A shared_ptr to a sensor_msgs::Image message
+ * \param use_dynamic_range If true, min_depth_range and max_depth_range will be retrieved from the image data
+ * \param encoding The desired encoding of the image data, one of the following strings:
+ *    - \c "mono8"
+ *    - \c "bgr8"
+ *    - \c "bgra8"
+ *    - \c "rgb8"
+ *    - \c "rgba8"
+ *    - \c "mono16"
+ * If \a encoding is the empty string (the default), the returned CvImage has the same encoding
+ * as \a source.
+ * \param min_depth_range Minimum depth range for the Kinect depth image data
+ * \param max_depth_range Maximum depth range for the Kinect depth image data
+ */
+CvImagePtr toCvCopy(const sensor_msgs::ImageConstPtr& source,
+                    bool use_dynamic_range,
+                    const std::string& encoding = std::string(),
+                    double min_depth_range = 0.0,
+                    double max_depth_range = 5.5);
 
 /**
  * \brief Convert an immutable sensor_msgs::Image message to an OpenCV-compatible CvImage, sharing

--- a/cv_bridge/include/cv_bridge/cv_bridge.h
+++ b/cv_bridge/include/cv_bridge/cv_bridge.h
@@ -191,11 +191,14 @@ CvImagePtr toCvCopy(const sensor_msgs::CompressedImage& source,
                     const std::string& encoding = std::string());
 
 /**
- * \brief Convert a sensor_msgs::Image message to an OpenCV-compatible CvImage.
- * Supports both color and depth Kinect image formats.
+ * \brief Convert an immutable sensor_msgs::Image message to an OpenCV-compatible CvImage, sharing
+ * the image data if possible.
+ *
+ * If the source encoding and desired encoding are the same, the returned CvImage will share
+ * the image data with \a source without copying it. The returned CvImage cannot be modified, as that
+ * could modify the \a source data.
  *
  * \param source   A shared_ptr to a sensor_msgs::Image message
- * \param use_dynamic_range If true, min_depth_range and max_depth_range will be retrieved from the image data
  * \param encoding The desired encoding of the image data, one of the following strings:
  *    - \c "mono8"
  *    - \c "bgr8"
@@ -203,16 +206,19 @@ CvImagePtr toCvCopy(const sensor_msgs::CompressedImage& source,
  *    - \c "rgb8"
  *    - \c "rgba8"
  *    - \c "mono16"
- * If \a encoding is the empty string (the default), the returned CvImage has the same encoding
+ *
+ * If \a encoding is the empty string (the default), the returned CvImage has the same encoding.
  * as \a source.
- * \param min_depth_range Minimum depth range for the Kinect depth image data
- * \param max_depth_range Maximum depth range for the Kinect depth image data
+ *
+ * \param use_dynamic_image_value If true, min_image_value and max_image_value will be retrieved from the image data.
+ * \param min_image_value Minimum image value
+ * \param max_image_value Maximum image value
  */
-CvImagePtr toCvCopy(const sensor_msgs::ImageConstPtr& source,
-                    bool use_dynamic_range,
-                    const std::string& encoding = std::string(),
-                    double min_depth_range = 0.0,
-                    double max_depth_range = 5.5);
+CvImageConstPtr cvtColorForDisplay(const sensor_msgs::ImageConstPtr& source,
+                                   const std::string& encoding = std::string(),
+                                   bool use_dynamic_image_value = true,
+                                   double min_image_value = 0.0,
+                                   double max_image_value = 5.5);
 
 /**
  * \brief Convert an immutable sensor_msgs::Image message to an OpenCV-compatible CvImage, sharing

--- a/cv_bridge/src/cv_bridge.cpp
+++ b/cv_bridge/src/cv_bridge.cpp
@@ -370,44 +370,48 @@ CvImagePtr toCvCopy(const sensor_msgs::Image& source,
   return toCvCopyImpl(matFromImage(source), source.header, source.encoding, encoding);
 }
 
-CvImagePtr toCvCopy(const sensor_msgs::ImageConstPtr& source,
-                    bool use_dynamic_range,
-                    const std::string& encoding,
-                    double min_depth_range,
-                    double max_depth_range)
+CvImageConstPtr cvtColorForDisplay(const sensor_msgs::ImageConstPtr& source,
+                                   const std::string& encoding,
+                                   bool use_dynamic_image_value,
+                                   double min_image_value,
+                                   double max_image_value)
 {
   try
   {
-    return cv_bridge::toCvCopy(source, encoding.empty() ? source->encoding : encoding);
+    return cv_bridge::toCvShare(source, encoding.empty() ? source->encoding : encoding);
   }
   catch (cv_bridge::Exception& e)
   {
     try
     {
-      cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(source);
       if (source->encoding == "CV_8UC3")
       {
-        return cv_ptr;
+        return cv_bridge::toCvShare(source);
       } else if (source->encoding == "8UC1") {
-        cv::Mat cv_image = cv_ptr->image;
-        cv::cvtColor(cv_image, cv_ptr->image, CV_GRAY2BGR);
-        cv_ptr->encoding = sensor_msgs::image_encodings::BGR8;
-        return cv_ptr;
+        cv_bridge::CvImageConstPtr cv_ptr = cv_bridge::toCvShare(source);
+        cv_bridge::CvImagePtr cv_ptr_cvt(new cv_bridge::CvImage());
+        cv::cvtColor(cv_ptr->image, cv_ptr_cvt->image, CV_GRAY2BGR);
+        cv_ptr_cvt->encoding = sensor_msgs::image_encodings::BGR8;
+        cv_ptr_cvt->header = cv_ptr->header;
+        return cv_ptr_cvt;
       } else if (source->encoding == "16UC1" || source->encoding == "32FC1") {
-        if (use_dynamic_range) cv::minMaxLoc(cv_ptr->image, &min_depth_range, &max_depth_range);
-        if (source->encoding == "16UC1") max_depth_range *= 1000;
+        cv_bridge::CvImageConstPtr cv_ptr = cv_bridge::toCvShare(source);
+        if (use_dynamic_image_value) cv::minMaxLoc(cv_ptr->image, &min_image_value, &max_image_value);
+        if (source->encoding == "16UC1") max_image_value *= 1000;
+        cv_bridge::CvImagePtr cv_ptr_cvt(new cv_bridge::CvImage());
         cv::Mat img_scaled_8u;
-        cv::Mat(cv_ptr->image-min_depth_range).convertTo(img_scaled_8u, CV_8UC1, 255. / (max_depth_range - min_depth_range));
-        cv::cvtColor(img_scaled_8u, cv_ptr->image, CV_GRAY2BGR);
-        cv_ptr->encoding = sensor_msgs::image_encodings::BGR8;
-        return cv_ptr;
+        cv::Mat(cv_ptr->image-min_image_value).convertTo(img_scaled_8u, CV_8UC1, 255.0 / (max_image_value - min_image_value));
+        cv::cvtColor(img_scaled_8u, cv_ptr_cvt->image, CV_GRAY2BGR);
+        cv_ptr_cvt->encoding = sensor_msgs::image_encodings::BGR8;
+        cv_ptr_cvt->header = cv_ptr->header;
+        return cv_ptr_cvt;
       } else {
-        throw Exception("ImageView.callback_image() could not convert image from '" + source->encoding + "' to 'rgb8' (" + e.what() + ")");
+        throw Exception("cv_bridge.cvtColorForDisplay() could not convert image from '" + source->encoding + "' to 'rgb8' (" + e.what() + ")");
       }
     }
     catch (cv_bridge::Exception& e)
     {
-      throw Exception("ImageView.callback_image() while trying to convert image from '" + source->encoding + "' to 'rgb8' an exception was thrown (" + e.what() + ")");
+      throw Exception("cv_bridge.cvtColorForDisplay() while trying to convert image from '" + source->encoding + "' to 'rgb8' an exception was thrown (" + e.what() + ")");
     }
   }
 }


### PR DESCRIPTION
Added sensor_msgs::Image conversion to cv::Mat from rqt_image_view in order to be able to create videos from kinect color and depth images
(cv_bridge
currently doesn't support 16UC1 image encoding).

Related PR:
https://github.com/ros-perception/image_pipeline/pull/147

Code adapted from:
https://github.com/ros-visualization/rqt_common_plugins/blob/groovy-devel/rqt_image_view/src/rqt_image_view/image_view.cpp
