### PR TITLE
[image_geometry]add a condition if D=None

### DIFF
--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -127,7 +127,7 @@ bool PinholeCameraModel::fromCameraInfo(const sensor_msgs::CameraInfo& msg)
   // Figure out how to handle the distortion
   if (cam_info_.distortion_model == sensor_msgs::distortion_models::PLUMB_BOB ||
       cam_info_.distortion_model == sensor_msgs::distortion_models::RATIONAL_POLYNOMIAL) {
-    cache_->distortion_state = (cam_info_.D[0] == 0.0) ? NONE : CALIBRATED;
+    cache_->distortion_state = (cam_info_.D.size() == 0 || (cam_info_.D[0] == 0.0)) ? NONE : CALIBRATED;
   }
   else
     cache_->distortion_state = UNKNOWN;


### PR DESCRIPTION
NULL D of pinhole_camera-parameter is supported in OpenCV.
http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html#projectpoints
Can this condition be added? without this, Segmentation fault may occur if D is null.
