### PR TITLE
fix depth conversion

### DIFF
--- a/cv_bridge/src/cv_bridge.cpp
+++ b/cv_bridge/src/cv_bridge.cpp
@@ -229,11 +229,11 @@ const std::vector<int> getConversionCode(std::string src_encoding, std::string d
                       "] to [" + dst_encoding + "]");
 
   // And deal with depth differences
-  std::vector<int> res = val->second;
+  std::vector<int> res;
   if (enc::bitDepth(src_encoding) != enc::bitDepth(dst_encoding))
     res.push_back(SAME_FORMAT);
-
-  return val->second;
+  res.insert(res.end(), val->second.begin(), val->second.end());
+  return res;
 }
 
 /////////////////////////////////////// Image ///////////////////////////////////////////


### PR DESCRIPTION
When trying to convert from MONO16 to BGR8 the order should be:

MONO16 -> MONO8
MONO8 -> BGR8

Currently we first try to call cvtColor with images of different depths and than try to fix the depth. This doesn't work.

see #83 
