### PR TITLE
[opencv_apps] fix bug for segment_objects_nodelet.cpp

### DIFF
--- a/opencv_apps/src/nodelet/segment_objects_nodelet.cpp
+++ b/opencv_apps/src/nodelet/segment_objects_nodelet.cpp
@@ -79,7 +79,7 @@ class SegmentObjectsNodelet : public nodelet::Nodelet
 #ifndef CV_VERSION_EPOCH
   cv::Ptr<cv::BackgroundSubtractorMOG2> bgsubtractor;
 #else
-  cv::BackgroundSubtractorMOG2 bgsubtractor;
+  cv::BackgroundSubtractorMOG bgsubtractor;
 #endif
   bool update_bg_model;
 


### PR DESCRIPTION
error for OpenCV 2

``` sh
$ roslaunch usb_cam usb_cam-test.launch 
$ rosrun opencv_apps segment_objects image:=/usb_cam/image_raw
OpenCV Error: Bad argument (No parameter 'noiseSigma' is found) in set, file /build/buildd/opencv-2.4.8+dfsg1/modules/core/src/algorithm.cpp, line 638
```
