### PR TITLE
cv_bridge: add OpenCV_INCLUDE_DIRS to INCLUDE_DIRS

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 find_package(OpenCV REQUIRED)
 
 catkin_package(
-  INCLUDE_DIRS include
+  INCLUDE_DIRS include ${OpenCV_INCLUDE_DIRS}
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS rosconsole sensor_msgs
   DEPENDS OpenCV


### PR DESCRIPTION
when we have installed both libopencv-dev and ros-indigo-opencv3, this will export include dir which is used for compilation time of cv_bridge
