### PR TITLE
Use respawn instead of watch

### DIFF
--- a/opencv_apps/package.xml
+++ b/opencv_apps/package.xml
@@ -31,7 +31,6 @@
   <test_depend>rosbag</test_depend>
   <test_depend>rosservice</test_depend>
   <test_depend>rostopic</test_depend>
-  <test_depend>procps</test_depend>
   <test_depend>image_proc</test_depend>
   <test_depend>image_view</test_depend>
   <test_depend>topic_tools</test_depend>

--- a/opencv_apps/test/test-lk_flow.test
+++ b/opencv_apps/test/test-lk_flow.test
@@ -14,7 +14,7 @@
       <param name="filename_format" value="$(find opencv_apps)/test/lk_flow.png"/>
     </node>
     <node name="lk_flow_initialize" pkg="rosservice" type="rosservice" args="call --wait lk_flow/initialize_points"
-          launch-prefix="watch" />
+          respawn="true" respawn_delay="2" />
     <param name="lk_flow_test/topic" value="lk_flow/flows" />    <!-- opencv_apps/FlowArrayStamped -->
     <test test-name="lk_flow_test" pkg="rostest" type="hztest" name="lk_flow_test" >
       <param name="hz" value="15" />


### PR DESCRIPTION
Proposed fix for #106 . Tests pass on Ubuntu, without the use of `watch`
