### PR TITLE
Refactor opencv_apps to remove duplicated codes to handle connection of topics.

### DIFF
--- a/opencv_apps/CMakeLists.txt
+++ b/opencv_apps/CMakeLists.txt
@@ -71,7 +71,7 @@ generate_messages(
 
 catkin_package()
 
-include_directories( ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 
 ## Declare a cpp library
 if(OPENCV_HAVE_OPTFLOW)
@@ -79,6 +79,7 @@ if(OPENCV_HAVE_OPTFLOW)
 endif()
 
 add_library(${PROJECT_NAME} SHARED
+  src/nodelet/nodelet.cpp
   # https://github.com/Itseez/opencv/blob/2.4/samples/cpp/tutorial_code
   # ImgTrans
   src/nodelet/edge_detection_nodelet.cpp
@@ -293,7 +294,8 @@ add_executable(watershed_segmentation_exe src/node/watershed_segmentation.cpp)
 SET_TARGET_PROPERTIES(watershed_segmentation_exe PROPERTIES OUTPUT_NAME watershed_segmentation)
 target_link_libraries(watershed_segmentation_exe ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
-
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 install(TARGETS edge_detection_exe hough_lines_exe hough_circles_exe face_detection_exe goodfeature_track_exe
   camshift_exe simple_example_exe simple_compressed_example_exe fback_flow_exe lk_flow_exe people_detect_exe phase_corr_exe segment_objects_exe watershed_segmentation_exe
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/opencv_apps/include/opencv_apps/nodelet.h
+++ b/opencv_apps/include/opencv_apps/nodelet.h
@@ -1,0 +1,318 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2016, Ryohei Ueda.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Kei Okada nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef OPENCV_APPS_NODELET_H_
+#define OPENCV_APPS_NODELET_H_
+
+#include <ros/ros.h>
+#include <nodelet/nodelet.h>
+#include <boost/thread.hpp>
+#include <image_transport/image_transport.h>
+
+namespace opencv_apps
+{
+  /** @brief
+   * Enum to represent connection status.
+   */
+  enum ConnectionStatus
+  {
+    NOT_INITIALIZED,
+    NOT_SUBSCRIBED,
+    SUBSCRIBED
+  };
+  
+  /** @brief
+   * Nodelet to automatically subscribe/unsubscribe
+   * topics according to subscription of advertised topics.
+   *
+   * It's important not to subscribe topic if no output is required.
+   *
+   * In order to watch advertised topics, need to use advertise template method.
+   * And create subscribers in subscribe() and shutdown them in unsubscribed().
+   *
+   */
+  class Nodelet: public nodelet::Nodelet
+  {
+  public:
+    Nodelet(): subscribed_(false) { }
+  protected:
+    
+    /** @brief
+     * Initialize nodehandles nh_ and pnh_. Subclass should call
+     * this method in its onInit method
+     */
+    virtual void onInit();
+
+
+    /** @brief
+     * Post processing of initialization of nodelet.
+     * You need to call this method in order to use always_subscribe
+     * feature.
+     */
+    virtual void onInitPostProcess();
+    
+    /** @brief
+     * callback function which is called when new subscriber come
+     */
+    virtual void connectionCallback(const ros::SingleSubscriberPublisher& pub);
+
+    /** @brief
+     * callback function which is called when new subscriber come for image
+     * publisher
+     */
+    virtual void imageConnectionCallback(
+      const image_transport::SingleSubscriberPublisher& pub);
+
+    /** @brief
+     * callback function which is called when new subscriber come for camera
+     * image publisher
+     */
+    virtual void cameraConnectionCallback(
+      const image_transport::SingleSubscriberPublisher& pub);
+    
+    /** @brief
+     * callback function which is called when new subscriber come for
+     * camera info publisher
+     */
+    virtual void cameraInfoConnectionCallback(
+      const ros::SingleSubscriberPublisher& pub);
+    
+    /** @brief
+     * callback function which is called when new subscriber come for camera
+     * image publisher or camera info publisher.
+     * This function is called from cameraConnectionCallback
+     * or cameraInfoConnectionCallback.
+     */
+    virtual void cameraConnectionBaseCallback();
+
+    /** @brief
+     * callback function which is called when walltimer
+     * duration run out.
+     */
+    virtual void warnNeverSubscribedCallback(const ros::WallTimerEvent& event);
+
+    /** @brief
+     * This method is called when publisher is subscribed by other
+     * nodes. 
+     * Set up subscribers in this method.
+     */
+    virtual void subscribe() = 0;
+
+    /** @brief
+     * This method is called when publisher is unsubscribed by other
+     * nodes.
+     * Shut down subscribers in this method.
+     */
+    virtual void unsubscribe() = 0;
+
+    /** @brief
+     * Advertise a topic and watch the publisher. Publishers which are
+     * created by this method.
+     * It automatically reads latch boolean parameter from nh and 
+     * publish topic with appropriate latch parameter.
+     *
+     * @param nh NodeHandle.
+     * @param topic topic name to advertise.
+     * @param queue_size queue size for publisher.
+     * @param latch set true if latch topic publication.
+     * @return Publisher for the advertised topic.
+     */
+    template<class T> ros::Publisher
+    advertise(ros::NodeHandle& nh,
+              std::string topic, int queue_size)
+    {
+      boost::mutex::scoped_lock lock(connection_mutex_);
+      ros::SubscriberStatusCallback connect_cb
+        = boost::bind(&Nodelet::connectionCallback, this, _1);
+      ros::SubscriberStatusCallback disconnect_cb
+        = boost::bind(&Nodelet::connectionCallback, this, _1);
+      bool latch;
+      nh.param("latch", latch, false);
+      ros::Publisher ret = nh.advertise<T>(topic, queue_size,
+                                           connect_cb,
+                                           disconnect_cb,
+                                           ros::VoidConstPtr(),
+                                           latch);
+      publishers_.push_back(ret);
+      
+      return ret;
+    }
+
+    /** @brief
+     * Advertise an image topic and watch the publisher. Publishers which are
+     * created by this method.
+     * It automatically reads latch boolean parameter from nh and it and
+     * publish topic with appropriate latch parameter.
+     *
+     * @param nh NodeHandle.
+     * @param topic topic name to advertise.
+     * @param queue_size queue size for publisher.
+     * @param latch set true if latch topic publication.
+     * @return Publisher for the advertised topic.
+     */
+    image_transport::Publisher
+    advertiseImage(ros::NodeHandle& nh,
+                   const std::string& topic,
+                   int queue_size)
+    {
+      boost::mutex::scoped_lock lock(connection_mutex_);
+      image_transport::SubscriberStatusCallback connect_cb
+        = boost::bind(&Nodelet::imageConnectionCallback,
+                      this, _1);
+      image_transport::SubscriberStatusCallback disconnect_cb
+        = boost::bind(&Nodelet::imageConnectionCallback,
+                      this, _1);
+      bool latch;
+      nh.param("latch", latch, false);
+      image_transport::Publisher pub
+        = image_transport::ImageTransport(nh).advertise(
+          topic, 1,
+          connect_cb, disconnect_cb,
+          ros::VoidPtr(), latch);
+      image_publishers_.push_back(pub);
+      return pub;
+    }
+
+    /** @brief
+     * Advertise an image topic camera info topic and watch the publisher.
+     * Publishers which are
+     * created by this method.
+     * It automatically reads latch boolean parameter from nh and it and
+     * publish topic with appropriate latch parameter.
+     *
+     * @param nh NodeHandle.
+     * @param topic topic name to advertise.
+     * @param queue_size queue size for publisher.
+     * @param latch set true if latch topic publication.
+     * @return Publisher for the advertised topic.
+     */
+    image_transport::CameraPublisher
+    advertiseCamera(ros::NodeHandle& nh,
+                    const std::string& topic,
+                    int queue_size)
+    {
+      boost::mutex::scoped_lock lock(connection_mutex_);
+      image_transport::SubscriberStatusCallback connect_cb
+        = boost::bind(&Nodelet::cameraConnectionCallback,
+                      this, _1);
+      image_transport::SubscriberStatusCallback disconnect_cb
+        = boost::bind(&Nodelet::cameraConnectionCallback,
+                      this, _1);
+      ros::SubscriberStatusCallback info_connect_cb
+        = boost::bind(&Nodelet::cameraInfoConnectionCallback,
+                      this, _1);
+      ros::SubscriberStatusCallback info_disconnect_cb
+        = boost::bind(&Nodelet::cameraInfoConnectionCallback,
+                      this, _1);
+      bool latch;
+      nh.param("latch", latch, false);
+      image_transport::CameraPublisher
+        pub = image_transport::ImageTransport(nh).advertiseCamera(topic, 1,
+                                                                  connect_cb, disconnect_cb,
+                                                                  info_connect_cb, info_disconnect_cb,
+                                                                  ros::VoidPtr(),
+                                                                  latch);
+      camera_publishers_.push_back(pub);
+      return pub;
+    }
+    
+    /** @brief
+     * mutex to call subscribe() and unsubscribe() in
+     * critical section.
+     */
+    boost::mutex connection_mutex_;
+    
+    /** @brief
+     * List of watching publishers
+     */
+    std::vector<ros::Publisher> publishers_;
+
+    /** @brief
+     * List of watching image publishers
+     */
+    std::vector<image_transport::Publisher> image_publishers_;
+
+    /** @brief
+     * List of watching camera publishers
+     */
+    std::vector<image_transport::CameraPublisher> camera_publishers_;
+
+    /** @brief
+     * Shared pointer to nodehandle.
+     */
+    boost::shared_ptr<ros::NodeHandle> nh_;
+
+    /** @brief
+     * Shared pointer to private nodehandle.
+     */
+    boost::shared_ptr<ros::NodeHandle> pnh_;
+
+    /** @brief
+     * WallTimer instance for warning about no connection.
+     */
+    ros::WallTimer timer_;
+
+    /** @brief
+     * A flag to check if any publisher is already subscribed
+     * or not.
+     */
+    bool subscribed_;
+
+    /** @brief
+     * A flag to check if the node has been ever subscribed
+     * or not.
+     */
+    bool ever_subscribed_;
+
+    /** @brief
+     * A flag to disable watching mechanism and always subscribe input 
+     * topics. It can be specified via ~always_subscribe parameter.
+     */
+    bool always_subscribe_;
+
+    /** @brief
+     * Status of connection
+     */
+    ConnectionStatus connection_status_;
+
+    /** @brief
+     * true if `~verbose_connection` or `verbose_connection` parameter is true.
+     */
+    bool verbose_connection_;
+  private:
+    
+  };
+}
+
+#endif

--- a/opencv_apps/src/nodelet/contour_moments_nodelet.cpp
+++ b/opencv_apps/src/nodelet/contour_moments_nodelet.cpp
@@ -40,7 +40,7 @@
  */
 
 #include <ros/ros.h>
-#include <nodelet/nodelet.h>
+#include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/image_encodings.h>
 #include <cv_bridge/cv_bridge.h>
@@ -55,7 +55,7 @@
 #include "opencv_apps/MomentArrayStamped.h"
 
 namespace contour_moments {
-class ContourMomentsNodelet : public nodelet::Nodelet
+class ContourMomentsNodelet : public opencv_apps::Nodelet
 {
   image_transport::Publisher img_pub_;
   image_transport::Subscriber img_sub_;
@@ -63,13 +63,11 @@ class ContourMomentsNodelet : public nodelet::Nodelet
   ros::Publisher msg_pub_;
 
   boost::shared_ptr<image_transport::ImageTransport> it_;
-  ros::NodeHandle nh_, local_nh_;
 
   contour_moments::ContourMomentsConfig config_;
   dynamic_reconfigure::Server<contour_moments::ContourMomentsConfig> srv;
 
   bool debug_view_;
-  int subscriber_count_;
   ros::Time prev_stamp_;
 
   int low_threshold_;
@@ -81,11 +79,6 @@ class ContourMomentsNodelet : public nodelet::Nodelet
   {
     config_ = new_config;
     low_threshold_ = config_.canny_low_threshold;
-    if (subscriber_count_)
-    { // @todo Could do this without an interruption at some point.
-      unsubscribe();
-      subscribe();
-    }
   }
 
   const std::string &frameWithDefault(const std::string &frame, const std::string &image_frame)
@@ -243,64 +236,28 @@ class ContourMomentsNodelet : public nodelet::Nodelet
     cam_sub_.shutdown();
   }
 
-  void img_connectCb(const image_transport::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void img_disconnectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
-  void msg_connectCb(const ros::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void msg_disconnectCb(const ros::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
 public:
   virtual void onInit()
   {
-    nh_ = getNodeHandle();
-    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
-    local_nh_ = ros::NodeHandle("~");
+    Nodelet::onInit();
+    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(*nh_));
 
-    local_nh_.param("debug_view", debug_view_, false);
-    subscriber_count_ = 0;
+    pnh_->param("debug_view", debug_view_, false);
+    if (debug_view_) {
+      always_subscribe_ = true;
+    }
     prev_stamp_ = ros::Time(0, 0);
 
     window_name_ = "Contours";
     low_threshold_ = 100; // only for canny
-
-    image_transport::SubscriberStatusCallback img_connect_cb    = boost::bind(&ContourMomentsNodelet::img_connectCb, this, _1);
-    image_transport::SubscriberStatusCallback img_disconnect_cb = boost::bind(&ContourMomentsNodelet::img_disconnectCb, this, _1);
-    ros::SubscriberStatusCallback msg_connect_cb    = boost::bind(&ContourMomentsNodelet::msg_connectCb, this, _1);
-    ros::SubscriberStatusCallback msg_disconnect_cb = boost::bind(&ContourMomentsNodelet::msg_disconnectCb, this, _1);
-    img_pub_ = image_transport::ImageTransport(local_nh_).advertise("image", 1, img_connect_cb, img_disconnect_cb);
-    msg_pub_ = local_nh_.advertise<opencv_apps::MomentArrayStamped>("moments", 1, msg_connect_cb, msg_disconnect_cb);
-
-    if( debug_view_ ) {
-      subscriber_count_++;
-    }
-
+    
     dynamic_reconfigure::Server<contour_moments::ContourMomentsConfig>::CallbackType f =
       boost::bind(&ContourMomentsNodelet::reconfigureCallback, this, _1, _2);
     srv.setCallback(f);
+
+    img_pub_ = advertiseImage(*pnh_, "image", 1);
+    msg_pub_ = advertise<opencv_apps::MomentArrayStamped>(*pnh_, "moments", 1);
+    onInitPostProcess();
   }
 };
 bool ContourMomentsNodelet::need_config_update_ = false;

--- a/opencv_apps/src/nodelet/edge_detection_nodelet.cpp
+++ b/opencv_apps/src/nodelet/edge_detection_nodelet.cpp
@@ -50,7 +50,7 @@
  */
 
 #include <ros/ros.h>
-#include <nodelet/nodelet.h>
+#include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/image_encodings.h>
 #include <cv_bridge/cv_bridge.h>
@@ -62,7 +62,7 @@
 #include "opencv_apps/EdgeDetectionConfig.h"
 
 namespace edge_detection {
-class EdgeDetectionNodelet : public nodelet::Nodelet
+class EdgeDetectionNodelet : public opencv_apps::Nodelet
 {
   image_transport::Publisher img_pub_;
   image_transport::Subscriber img_sub_;
@@ -70,13 +70,11 @@ class EdgeDetectionNodelet : public nodelet::Nodelet
   ros::Publisher msg_pub_;
 
   boost::shared_ptr<image_transport::ImageTransport> it_;
-  ros::NodeHandle nh_, local_nh_;
 
   edge_detection::EdgeDetectionConfig config_;
   dynamic_reconfigure::Server<edge_detection::EdgeDetectionConfig> srv;
 
   bool debug_view_;
-  int subscriber_count_;
   ros::Time prev_stamp_;
 
   int low_threshold_;
@@ -88,11 +86,6 @@ class EdgeDetectionNodelet : public nodelet::Nodelet
   {
     config_ = new_config;
     low_threshold_ = config_.canny_low_threshold;
-    if (subscriber_count_)
-    { // @todo Could do this without an interruption at some point.
-      unsubscribe();
-      subscribe();
-    }
   }
 
   const std::string &frameWithDefault(const std::string &frame, const std::string &image_frame)
@@ -254,64 +247,29 @@ class EdgeDetectionNodelet : public nodelet::Nodelet
     cam_sub_.shutdown();
   }
 
-  void img_connectCb(const image_transport::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void img_disconnectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
-  void msg_connectCb(const ros::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void msg_disconnectCb(const ros::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
 public:
   virtual void onInit()
   {
-    nh_ = getNodeHandle();
-    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
-    local_nh_ = ros::NodeHandle("~");
+    Nodelet::onInit();
+    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(*nh_));
 
-    local_nh_.param("debug_view", debug_view_, false);
-    subscriber_count_ = 0;
+    pnh_->param("debug_view", debug_view_, false);
+    if (debug_view_) {
+      always_subscribe_ = true;
+    }
     prev_stamp_ = ros::Time(0, 0);
 
     window_name_ = "Edge Detection Demo";
     low_threshold_ = 10; // only for canny
 
-    image_transport::SubscriberStatusCallback img_connect_cb    = boost::bind(&EdgeDetectionNodelet::img_connectCb, this, _1);
-    image_transport::SubscriberStatusCallback img_disconnect_cb = boost::bind(&EdgeDetectionNodelet::img_disconnectCb, this, _1);
-    ros::SubscriberStatusCallback msg_connect_cb    = boost::bind(&EdgeDetectionNodelet::msg_connectCb, this, _1);
-    ros::SubscriberStatusCallback msg_disconnect_cb = boost::bind(&EdgeDetectionNodelet::msg_disconnectCb, this, _1);
-    img_pub_ = image_transport::ImageTransport(local_nh_).advertise("image", 1, img_connect_cb, img_disconnect_cb);
-    //msg_pub_ = local_nh_.advertise<opencv_apps::LineArrayStamped>("lines", 1, msg_connect_cb, msg_disconnect_cb);
-
-    if( debug_view_ ) {
-      subscriber_count_++;
-    }
-
     dynamic_reconfigure::Server<edge_detection::EdgeDetectionConfig>::CallbackType f =
       boost::bind(&EdgeDetectionNodelet::reconfigureCallback, this, _1, _2);
     srv.setCallback(f);
+    
+    img_pub_ = advertiseImage(*pnh_, "image", 1);
+    //msg_pub_ = local_nh_.advertise<opencv_apps::LineArrayStamped>("lines", 1, msg_connect_cb, msg_disconnect_cb);
+
+    onInitPostProcess();
   }
 };
 bool EdgeDetectionNodelet::need_config_update_ = false;

--- a/opencv_apps/src/nodelet/face_detection_nodelet.cpp
+++ b/opencv_apps/src/nodelet/face_detection_nodelet.cpp
@@ -40,7 +40,7 @@
  */
 
 #include <ros/ros.h>
-#include <nodelet/nodelet.h>
+#include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 
@@ -55,7 +55,7 @@
 #include "opencv_apps/FaceArrayStamped.h"
 
 namespace face_detection {
-class FaceDetectionNodelet : public nodelet::Nodelet
+class FaceDetectionNodelet : public opencv_apps::Nodelet
 {
   image_transport::Publisher img_pub_;
   image_transport::Subscriber img_sub_;
@@ -63,13 +63,11 @@ class FaceDetectionNodelet : public nodelet::Nodelet
   ros::Publisher msg_pub_;
 
   boost::shared_ptr<image_transport::ImageTransport> it_;
-  ros::NodeHandle nh_, local_nh_;
 
   face_detection::FaceDetectionConfig config_;
   dynamic_reconfigure::Server<face_detection::FaceDetectionConfig> srv;
 
   bool debug_view_;
-  int subscriber_count_;
   ros::Time prev_stamp_;
 
   cv::CascadeClassifier face_cascade_;
@@ -78,11 +76,6 @@ class FaceDetectionNodelet : public nodelet::Nodelet
   void reconfigureCallback(face_detection::FaceDetectionConfig &new_config, uint32_t level)
   {
     config_ = new_config;
-    if (subscriber_count_)
-    { // @todo Could do this without an interruption at some point.
-      unsubscribe();
-      subscribe();
-    }
   }
 
   const std::string &frameWithDefault(const std::string &frame, const std::string &image_frame)
@@ -202,67 +195,33 @@ class FaceDetectionNodelet : public nodelet::Nodelet
     cam_sub_.shutdown();
   }
 
-  void img_connectCb(const image_transport::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void img_disconnectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
-  void msg_connectCb(const ros::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void msg_disconnectCb(const ros::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
 public:
   virtual void onInit()
   {
-    nh_ = getNodeHandle();
-    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
-    local_nh_ = ros::NodeHandle("~");
+    Nodelet::onInit();
+    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(*nh_));
 
-    local_nh_.param("debug_view", debug_view_, false);
-    subscriber_count_ = 0;
-    prev_stamp_ = ros::Time(0, 0);
-
-    image_transport::SubscriberStatusCallback img_connect_cb    = boost::bind(&FaceDetectionNodelet::img_connectCb, this, _1);
-    image_transport::SubscriberStatusCallback img_disconnect_cb = boost::bind(&FaceDetectionNodelet::img_disconnectCb, this, _1);
-    ros::SubscriberStatusCallback msg_connect_cb    = boost::bind(&FaceDetectionNodelet::msg_connectCb, this, _1);
-    ros::SubscriberStatusCallback msg_disconnect_cb = boost::bind(&FaceDetectionNodelet::msg_disconnectCb, this, _1);
-    img_pub_ = image_transport::ImageTransport(local_nh_).advertise("image", 1, img_connect_cb, img_disconnect_cb);
-    msg_pub_ = local_nh_.advertise<opencv_apps::FaceArrayStamped>("faces", 1, msg_connect_cb, msg_disconnect_cb);
-
-    if( debug_view_ ) {
-      subscriber_count_++;
+    pnh_->param("debug_view", debug_view_, false);
+    if (debug_view_ ) {
+      always_subscribe_ = true;
     }
-    std::string face_cascade_name, eyes_cascade_name;
-    local_nh_.param("face_cascade_name", face_cascade_name, std::string("/usr/share/opencv/haarcascades/haarcascade_frontalface_alt.xml"));
-    local_nh_.param("eyes_cascade_name", eyes_cascade_name, std::string("/usr/share/opencv/haarcascades/haarcascade_eye_tree_eyeglasses.xml"));
-
-    if( !face_cascade_.load( face_cascade_name ) ){ NODELET_ERROR("--Error loading %s", face_cascade_name.c_str()); };
-    if( !eyes_cascade_.load( eyes_cascade_name ) ){ NODELET_ERROR("--Error loading %s", eyes_cascade_name.c_str()); };
+    prev_stamp_ = ros::Time(0, 0);
 
     dynamic_reconfigure::Server<face_detection::FaceDetectionConfig>::CallbackType f =
       boost::bind(&FaceDetectionNodelet::reconfigureCallback, this, _1, _2);
     srv.setCallback(f);
+    
+    img_pub_ = advertiseImage(*pnh_, "image", 1);
+    msg_pub_ = advertise<opencv_apps::FaceArrayStamped>(*pnh_, "faces", 1);
+
+    std::string face_cascade_name, eyes_cascade_name;
+    pnh_->param("face_cascade_name", face_cascade_name, std::string("/usr/share/opencv/haarcascades/haarcascade_frontalface_alt.xml"));
+    pnh_->param("eyes_cascade_name", eyes_cascade_name, std::string("/usr/share/opencv/haarcascades/haarcascade_eye_tree_eyeglasses.xml"));
+
+    if( !face_cascade_.load( face_cascade_name ) ){ NODELET_ERROR("--Error loading %s", face_cascade_name.c_str()); };
+    if( !eyes_cascade_.load( eyes_cascade_name ) ){ NODELET_ERROR("--Error loading %s", eyes_cascade_name.c_str()); };
+
+    onInitPostProcess();
   }
 };
 }

--- a/opencv_apps/src/nodelet/fback_flow_nodelet.cpp
+++ b/opencv_apps/src/nodelet/fback_flow_nodelet.cpp
@@ -39,7 +39,7 @@
  */
 
 #include <ros/ros.h>
-#include <nodelet/nodelet.h>
+#include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 
@@ -52,7 +52,7 @@
 #include "opencv_apps/FlowArrayStamped.h"
 
 namespace fback_flow {
-class FBackFlowNodelet : public nodelet::Nodelet
+class FBackFlowNodelet : public opencv_apps::Nodelet
 {
   image_transport::Publisher img_pub_;
   image_transport::Subscriber img_sub_;
@@ -60,13 +60,11 @@ class FBackFlowNodelet : public nodelet::Nodelet
   ros::Publisher msg_pub_;
 
   boost::shared_ptr<image_transport::ImageTransport> it_;
-  ros::NodeHandle nh_, local_nh_;
 
   fback_flow::FBackFlowConfig config_;
   dynamic_reconfigure::Server<fback_flow::FBackFlowConfig> srv;
 
   bool debug_view_;
-  int subscriber_count_;
   ros::Time prev_stamp_;
 
   std::string window_name_;
@@ -77,11 +75,6 @@ class FBackFlowNodelet : public nodelet::Nodelet
   void reconfigureCallback(fback_flow::FBackFlowConfig &new_config, uint32_t level)
   {
     config_ = new_config;
-    if (subscriber_count_)
-    { // @todo Could do this without an interruption at some point.
-      unsubscribe();
-      subscribe();
-    }
   }
 
   const std::string &frameWithDefault(const std::string &frame, const std::string &image_frame)
@@ -198,63 +191,28 @@ class FBackFlowNodelet : public nodelet::Nodelet
     cam_sub_.shutdown();
   }
 
-  void img_connectCb(const image_transport::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void img_disconnectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
-  void msg_connectCb(const ros::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void msg_disconnectCb(const ros::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
 public:
   virtual void onInit()
   {
-    nh_ = getNodeHandle();
-    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
-    local_nh_ = ros::NodeHandle("~");
+    Nodelet::onInit();
+    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(*nh_));
 
-    local_nh_.param("debug_view", debug_view_, false);
-    subscriber_count_ = 0;
+    pnh_->param("debug_view", debug_view_, false);
+    if (debug_view_) {
+      always_subscribe_ = true;
+    }
     prev_stamp_ = ros::Time(0, 0);
 
     window_name_ = "flow";
-
-    image_transport::SubscriberStatusCallback img_connect_cb    = boost::bind(&FBackFlowNodelet::img_connectCb, this, _1);
-    image_transport::SubscriberStatusCallback img_disconnect_cb = boost::bind(&FBackFlowNodelet::img_disconnectCb, this, _1);
-    ros::SubscriberStatusCallback msg_connect_cb    = boost::bind(&FBackFlowNodelet::msg_connectCb, this, _1);
-    ros::SubscriberStatusCallback msg_disconnect_cb = boost::bind(&FBackFlowNodelet::msg_disconnectCb, this, _1);
-    img_pub_ = image_transport::ImageTransport(local_nh_).advertise("image", 1, img_connect_cb, img_disconnect_cb);
-    msg_pub_ = local_nh_.advertise<opencv_apps::FlowArrayStamped>("flows", 1, msg_connect_cb, msg_disconnect_cb);
-
-    if( debug_view_ ) {
-      subscriber_count_++;
-    }
-
+    
     dynamic_reconfigure::Server<fback_flow::FBackFlowConfig>::CallbackType f =
       boost::bind(&FBackFlowNodelet::reconfigureCallback, this, _1, _2);
     srv.setCallback(f);
+
+    img_pub_ = advertiseImage(*pnh_, "image", 1);
+    msg_pub_ = advertise<opencv_apps::FlowArrayStamped>(*pnh_, "flows", 1);
+
+    onInitPostProcess();
   }
 };
 bool FBackFlowNodelet::need_config_update_ = false;

--- a/opencv_apps/src/nodelet/find_contours_nodelet.cpp
+++ b/opencv_apps/src/nodelet/find_contours_nodelet.cpp
@@ -40,7 +40,7 @@
  */
 
 #include <ros/ros.h>
-#include <nodelet/nodelet.h>
+#include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/image_encodings.h>
 #include <cv_bridge/cv_bridge.h>
@@ -55,7 +55,7 @@
 #include "opencv_apps/ContourArrayStamped.h"
 
 namespace find_contours {
-class FindContoursNodelet : public nodelet::Nodelet
+class FindContoursNodelet : public opencv_apps::Nodelet
 {
   image_transport::Publisher img_pub_;
   image_transport::Subscriber img_sub_;
@@ -63,13 +63,11 @@ class FindContoursNodelet : public nodelet::Nodelet
   ros::Publisher msg_pub_;
 
   boost::shared_ptr<image_transport::ImageTransport> it_;
-  ros::NodeHandle nh_, local_nh_;
 
   find_contours::FindContoursConfig config_;
   dynamic_reconfigure::Server<find_contours::FindContoursConfig> srv;
 
   bool debug_view_;
-  int subscriber_count_;
   ros::Time prev_stamp_;
 
   int low_threshold_;
@@ -81,11 +79,6 @@ class FindContoursNodelet : public nodelet::Nodelet
   {
     config_ = new_config;
     low_threshold_ = config_.canny_low_threshold;
-    if (subscriber_count_)
-    { // @todo Could do this without an interruption at some point.
-      unsubscribe();
-      subscribe();
-    }
   }
 
   const std::string &frameWithDefault(const std::string &frame, const std::string &image_frame)
@@ -212,64 +205,29 @@ class FindContoursNodelet : public nodelet::Nodelet
     cam_sub_.shutdown();
   }
 
-  void img_connectCb(const image_transport::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void img_disconnectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
-  void msg_connectCb(const ros::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void msg_disconnectCb(const ros::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
 public:
   virtual void onInit()
   {
-    nh_ = getNodeHandle();
-    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
-    local_nh_ = ros::NodeHandle("~");
+    Nodelet::onInit();
+    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(*nh_));
 
-    local_nh_.param("debug_view", debug_view_, false);
-    subscriber_count_ = 0;
+    pnh_->param("debug_view", debug_view_, false);
+    if (debug_view_) {
+      always_subscribe_ = true;
+    }
     prev_stamp_ = ros::Time(0, 0);
 
     window_name_ = "Demo code to find contours in an image";
     low_threshold_ = 100; // only for canny
-
-    image_transport::SubscriberStatusCallback img_connect_cb    = boost::bind(&FindContoursNodelet::img_connectCb, this, _1);
-    image_transport::SubscriberStatusCallback img_disconnect_cb = boost::bind(&FindContoursNodelet::img_disconnectCb, this, _1);
-    ros::SubscriberStatusCallback msg_connect_cb    = boost::bind(&FindContoursNodelet::msg_connectCb, this, _1);
-    ros::SubscriberStatusCallback msg_disconnect_cb = boost::bind(&FindContoursNodelet::msg_disconnectCb, this, _1);
-    img_pub_ = image_transport::ImageTransport(local_nh_).advertise("image", 1, img_connect_cb, img_disconnect_cb);
-    msg_pub_ = local_nh_.advertise<opencv_apps::ContourArrayStamped>("contours", 1, msg_connect_cb, msg_disconnect_cb);
-        
-    if( debug_view_ ) {
-      subscriber_count_++;
-    }
-
+    
     dynamic_reconfigure::Server<find_contours::FindContoursConfig>::CallbackType f =
       boost::bind(&FindContoursNodelet::reconfigureCallback, this, _1, _2);
     srv.setCallback(f);
+
+    img_pub_ = advertiseImage(*pnh_, "image", 1);
+    msg_pub_ = advertise<opencv_apps::ContourArrayStamped>(*pnh_, "contours", 1);
+
+    onInitPostProcess();
   }
 };
 bool FindContoursNodelet::need_config_update_ = false;

--- a/opencv_apps/src/nodelet/general_contours_nodelet.cpp
+++ b/opencv_apps/src/nodelet/general_contours_nodelet.cpp
@@ -40,7 +40,7 @@
  */
 
 #include <ros/ros.h>
-#include <nodelet/nodelet.h>
+#include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/image_encodings.h>
 #include <cv_bridge/cv_bridge.h>
@@ -55,7 +55,7 @@
 #include "opencv_apps/RotatedRectArrayStamped.h"
 
 namespace general_contours {
-class GeneralContoursNodelet : public nodelet::Nodelet
+class GeneralContoursNodelet : public opencv_apps::Nodelet
 {
   image_transport::Publisher img_pub_;
   image_transport::Subscriber img_sub_;
@@ -63,13 +63,11 @@ class GeneralContoursNodelet : public nodelet::Nodelet
   ros::Publisher rects_pub_, ellipses_pub_;
 
   boost::shared_ptr<image_transport::ImageTransport> it_;
-  ros::NodeHandle nh_, local_nh_;
 
   general_contours::GeneralContoursConfig config_;
   dynamic_reconfigure::Server<general_contours::GeneralContoursConfig> srv;
 
   bool debug_view_;
-  int subscriber_count_;
   ros::Time prev_stamp_;
 
   int threshold_;
@@ -81,11 +79,6 @@ class GeneralContoursNodelet : public nodelet::Nodelet
   {
     config_ = new_config;
     threshold_ = config_.threshold;
-    if (subscriber_count_)
-    { // @todo Could do this without an interruption at some point.
-      unsubscribe();
-      subscribe();
-    }
   }
 
   const std::string &frameWithDefault(const std::string &frame, const std::string &image_frame)
@@ -243,65 +236,30 @@ class GeneralContoursNodelet : public nodelet::Nodelet
     cam_sub_.shutdown();
   }
 
-  void img_connectCb(const image_transport::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void img_disconnectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
-  void msg_connectCb(const ros::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void msg_disconnectCb(const ros::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
 public:
   virtual void onInit()
   {
-    nh_ = getNodeHandle();
-    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
-    local_nh_ = ros::NodeHandle("~");
+    Nodelet::onInit();
+    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(*nh_));
 
-    local_nh_.param("debug_view", debug_view_, false);
-    subscriber_count_ = 0;
+    pnh_->param("debug_view", debug_view_, false);
+    if (debug_view_) {
+      always_subscribe_ = true;
+    }
     prev_stamp_ = ros::Time(0, 0);
 
     window_name_ = "Contours";
     threshold_ = 100;
 
-    image_transport::SubscriberStatusCallback img_connect_cb    = boost::bind(&GeneralContoursNodelet::img_connectCb, this, _1);
-    image_transport::SubscriberStatusCallback img_disconnect_cb = boost::bind(&GeneralContoursNodelet::img_disconnectCb, this, _1);
-    ros::SubscriberStatusCallback msg_connect_cb    = boost::bind(&GeneralContoursNodelet::msg_connectCb, this, _1);
-    ros::SubscriberStatusCallback msg_disconnect_cb = boost::bind(&GeneralContoursNodelet::msg_disconnectCb, this, _1);
-    img_pub_ = image_transport::ImageTransport(local_nh_).advertise("image", 1, img_connect_cb, img_disconnect_cb);
-    rects_pub_ = local_nh_.advertise<opencv_apps::RotatedRectArrayStamped>("rectangles", 1, msg_connect_cb, msg_disconnect_cb);
-    ellipses_pub_ = local_nh_.advertise<opencv_apps::RotatedRectArrayStamped>("ellipses", 1, msg_connect_cb, msg_disconnect_cb);
-
-    if( debug_view_ ) {
-      subscriber_count_++;
-    }
-
     dynamic_reconfigure::Server<general_contours::GeneralContoursConfig>::CallbackType f =
       boost::bind(&GeneralContoursNodelet::reconfigureCallback, this, _1, _2);
     srv.setCallback(f);
+    
+    img_pub_ = advertiseImage(*pnh_, "image", 1);
+    rects_pub_ = advertise<opencv_apps::RotatedRectArrayStamped>(*pnh_, "rectangles", 1);
+    ellipses_pub_ = advertise<opencv_apps::RotatedRectArrayStamped>(*pnh_, "ellipses", 1);
+
+    onInitPostProcess();
   }
 };
 bool GeneralContoursNodelet::need_config_update_ = false;

--- a/opencv_apps/src/nodelet/hough_lines_nodelet.cpp
+++ b/opencv_apps/src/nodelet/hough_lines_nodelet.cpp
@@ -40,7 +40,7 @@
  */
 
 #include <ros/ros.h>
-#include <nodelet/nodelet.h>
+#include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 
@@ -54,7 +54,7 @@
 #include "opencv_apps/LineArrayStamped.h"
 
 namespace hough_lines {
-class HoughLinesNodelet : public nodelet::Nodelet
+class HoughLinesNodelet : public opencv_apps::Nodelet
 {
   image_transport::Publisher img_pub_;
   image_transport::Subscriber img_sub_;
@@ -62,13 +62,11 @@ class HoughLinesNodelet : public nodelet::Nodelet
   ros::Publisher msg_pub_;
 
   boost::shared_ptr<image_transport::ImageTransport> it_;
-  ros::NodeHandle nh_, local_nh_;
 
   hough_lines::HoughLinesConfig config_;
   dynamic_reconfigure::Server<hough_lines::HoughLinesConfig> srv;
 
   bool debug_view_;
-  int subscriber_count_;
   ros::Time prev_stamp_;
 
   std::string window_name_;
@@ -82,11 +80,6 @@ class HoughLinesNodelet : public nodelet::Nodelet
   {
     config_ = new_config;
     threshold_ = config_.threshold;
-    if (subscriber_count_)
-    { // @todo Could do this without an interruption at some point.
-      unsubscribe();
-      subscribe();
-    }
   }
 
   const std::string &frameWithDefault(const std::string &frame, const std::string &image_frame)
@@ -249,45 +242,16 @@ class HoughLinesNodelet : public nodelet::Nodelet
     cam_sub_.shutdown();
   }
 
-  void img_connectCb(const image_transport::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void img_disconnectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
-  void msg_connectCb(const ros::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void msg_disconnectCb(const ros::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
 public:
   virtual void onInit()
   {
-    nh_ = getNodeHandle();
-    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
-    local_nh_ = ros::NodeHandle("~");
+    Nodelet::onInit();
+    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(*nh_));
 
-    local_nh_.param("debug_view", debug_view_, false);
-    subscriber_count_ = 0;
+    pnh_->param("debug_view", debug_view_, false);
+    if (debug_view_) {
+      always_subscribe_ = true;
+    }
     prev_stamp_ = ros::Time(0, 0);
 
     window_name_ = "Hough Lines Demo";
@@ -295,20 +259,14 @@ public:
     max_threshold_ = 150;
     threshold_ = max_threshold_;
 
-    image_transport::SubscriberStatusCallback img_connect_cb    = boost::bind(&HoughLinesNodelet::img_connectCb, this, _1);
-    image_transport::SubscriberStatusCallback img_disconnect_cb = boost::bind(&HoughLinesNodelet::img_disconnectCb, this, _1);
-    ros::SubscriberStatusCallback msg_connect_cb    = boost::bind(&HoughLinesNodelet::msg_connectCb, this, _1);
-    ros::SubscriberStatusCallback msg_disconnect_cb = boost::bind(&HoughLinesNodelet::msg_disconnectCb, this, _1);
-    img_pub_ = image_transport::ImageTransport(local_nh_).advertise("image", 1, img_connect_cb, img_disconnect_cb);
-    msg_pub_ = local_nh_.advertise<opencv_apps::LineArrayStamped>("lines", 1, msg_connect_cb, msg_disconnect_cb);
-
-    if( debug_view_ ) {
-      subscriber_count_++;
-    }
-
     dynamic_reconfigure::Server<hough_lines::HoughLinesConfig>::CallbackType f =
       boost::bind(&HoughLinesNodelet::reconfigureCallback, this, _1, _2);
     srv.setCallback(f);
+    
+    img_pub_ = advertiseImage(*pnh_, "image", 1);
+    msg_pub_ = advertise<opencv_apps::LineArrayStamped>(*pnh_, "lines", 1);
+
+    onInitPostProcess();
   }
 };
 bool HoughLinesNodelet::need_config_update_ = false;

--- a/opencv_apps/src/nodelet/lk_flow_nodelet.cpp
+++ b/opencv_apps/src/nodelet/lk_flow_nodelet.cpp
@@ -38,7 +38,7 @@
  */
 
 #include <ros/ros.h>
-#include <nodelet/nodelet.h>
+#include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 
@@ -52,7 +52,7 @@
 #include "opencv_apps/FlowArrayStamped.h"
 
 namespace lk_flow {
-class LKFlowNodelet : public nodelet::Nodelet
+class LKFlowNodelet : public opencv_apps::Nodelet
 {
   image_transport::Publisher img_pub_;
   image_transport::Subscriber img_sub_;
@@ -63,13 +63,11 @@ class LKFlowNodelet : public nodelet::Nodelet
   ros::ServiceServer toggle_night_mode_service_;
 
   boost::shared_ptr<image_transport::ImageTransport> it_;
-  ros::NodeHandle nh_, local_nh_;
 
   lk_flow::LKFlowConfig config_;
   dynamic_reconfigure::Server<lk_flow::LKFlowConfig> srv;
 
   bool debug_view_;
-  int subscriber_count_;
   ros::Time prev_stamp_;
 
   std::string window_name_;
@@ -86,11 +84,6 @@ class LKFlowNodelet : public nodelet::Nodelet
   void reconfigureCallback(lk_flow::LKFlowConfig &new_config, uint32_t level)
   {
     config_ = new_config;
-    if (subscriber_count_)
-    { // @todo Could do this without an interruption at some point.
-      unsubscribe();
-      subscribe();
-    }
   }
 
   const std::string &frameWithDefault(const std::string &frame, const std::string &image_frame)
@@ -290,45 +283,16 @@ class LKFlowNodelet : public nodelet::Nodelet
     cam_sub_.shutdown();
   }
 
-  void img_connectCb(const image_transport::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void img_disconnectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
-  void msg_connectCb(const ros::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void msg_disconnectCb(const ros::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
 public:
   virtual void onInit()
   {
-    nh_ = getNodeHandle();
-    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
-    local_nh_ = ros::NodeHandle("~");
+    Nodelet::onInit();
+    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(*nh_));
 
-    local_nh_.param("debug_view", debug_view_, false);
-    subscriber_count_ = 0;
+    pnh_->param("debug_view", debug_view_, false);
+    if (debug_view_) {
+      always_subscribe_ = true;
+    }
     prev_stamp_ = ros::Time(0, 0);
 
     window_name_ = "LK Demo";
@@ -337,23 +301,16 @@ public:
     nightMode = false;
     addRemovePt = false;
 
-    image_transport::SubscriberStatusCallback img_connect_cb    = boost::bind(&LKFlowNodelet::img_connectCb, this, _1);
-    image_transport::SubscriberStatusCallback img_disconnect_cb = boost::bind(&LKFlowNodelet::img_disconnectCb, this, _1);
-    ros::SubscriberStatusCallback msg_connect_cb    = boost::bind(&LKFlowNodelet::msg_connectCb, this, _1);
-    ros::SubscriberStatusCallback msg_disconnect_cb = boost::bind(&LKFlowNodelet::msg_disconnectCb, this, _1);
-    img_pub_ = image_transport::ImageTransport(local_nh_).advertise("image", 1, img_connect_cb, img_disconnect_cb);
-    msg_pub_ = local_nh_.advertise<opencv_apps::FlowArrayStamped>("flows", 1, msg_connect_cb, msg_disconnect_cb);
-    initialize_points_service_ = local_nh_.advertiseService("initialize_points", &LKFlowNodelet::initialize_points_cb, this);
-    delete_points_service_ = local_nh_.advertiseService("delete_points", &LKFlowNodelet::delete_points_cb, this);
-    toggle_night_mode_service_ = local_nh_.advertiseService("toggle_night_mode", &LKFlowNodelet::toggle_night_mode_cb, this);
-
-    if( debug_view_ ) {
-      subscriber_count_++;
-    }
-
     dynamic_reconfigure::Server<lk_flow::LKFlowConfig>::CallbackType f =
       boost::bind(&LKFlowNodelet::reconfigureCallback, this, _1, _2);
     srv.setCallback(f);
+    
+    img_pub_ = advertiseImage(*pnh_, "image", 1);
+    msg_pub_ = advertise<opencv_apps::FlowArrayStamped>(*pnh_, "flows", 1);
+    initialize_points_service_ = pnh_->advertiseService("initialize_points", &LKFlowNodelet::initialize_points_cb, this);
+    delete_points_service_ = pnh_->advertiseService("delete_points", &LKFlowNodelet::delete_points_cb, this);
+    toggle_night_mode_service_ = pnh_->advertiseService("toggle_night_mode", &LKFlowNodelet::toggle_night_mode_cb, this);
+
 
     NODELET_INFO("Hot keys: ");
     NODELET_INFO("\tESC - quit the program");
@@ -361,6 +318,8 @@ public:
     NODELET_INFO("\tc - delete all the points");
     NODELET_INFO("\tn - switch the \"night\" mode on/off");
     //NODELET_INFO("To add/remove a feature point click it");
+
+    onInitPostProcess();
   }
 };
 bool LKFlowNodelet::need_config_update_ = false;

--- a/opencv_apps/src/nodelet/nodelet.cpp
+++ b/opencv_apps/src/nodelet/nodelet.cpp
@@ -1,0 +1,184 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Ryohei Ueda.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "opencv_apps/nodelet.h"
+
+namespace opencv_apps
+{
+  void Nodelet::onInit()
+  {
+    connection_status_ = NOT_SUBSCRIBED;
+    nh_.reset (new ros::NodeHandle (getMTNodeHandle ()));
+    pnh_.reset (new ros::NodeHandle (getMTPrivateNodeHandle ()));
+    pnh_->param("always_subscribe", always_subscribe_, false);
+    pnh_->param("verbose_connection", verbose_connection_, false);
+    if (!verbose_connection_) {
+      nh_->param("verbose_connection", verbose_connection_, false);
+    }
+    // timer to warn when no connection in a few seconds
+    ever_subscribed_ = false;
+    timer_ = nh_->createWallTimer(
+      ros::WallDuration(5),
+      &Nodelet::warnNeverSubscribedCallback,
+      this,
+      /*oneshot=*/true);
+  }
+
+  void Nodelet::onInitPostProcess()
+  {
+    if (always_subscribe_) {
+      subscribe();
+    }
+  }
+
+  void Nodelet::warnNeverSubscribedCallback(const ros::WallTimerEvent& event)
+  {
+    if (!ever_subscribed_) {
+      NODELET_WARN("'%s' subscribes topics only with child subscribers.", nodelet::Nodelet::getName().c_str());
+    }
+  }
+
+  void Nodelet::connectionCallback(const ros::SingleSubscriberPublisher& pub)
+  {
+    if (verbose_connection_) {
+      NODELET_INFO("New connection or disconnection is detected");
+    }
+    if (!always_subscribe_) {
+      boost::mutex::scoped_lock lock(connection_mutex_);
+      for (size_t i = 0; i < publishers_.size(); i++) {
+        ros::Publisher pub = publishers_[i];
+        if (pub.getNumSubscribers() > 0) {
+          if (!ever_subscribed_) {
+            ever_subscribed_ = true;
+          }
+          if (connection_status_ != SUBSCRIBED) {
+            if (verbose_connection_) {
+              NODELET_INFO("Subscribe input topics");
+            }
+            subscribe();
+            connection_status_ = SUBSCRIBED;
+          }
+          return;
+        }
+      }
+      if (connection_status_ == SUBSCRIBED) {
+        if (verbose_connection_) {
+          NODELET_INFO("Unsubscribe input topics");
+        }
+        unsubscribe();
+        connection_status_ = NOT_SUBSCRIBED;
+      }
+    }
+  }
+  
+  void Nodelet::imageConnectionCallback(
+    const image_transport::SingleSubscriberPublisher& pub)
+  {
+    if (verbose_connection_) {
+      NODELET_INFO("New image connection or disconnection is detected");
+    }
+    if (!always_subscribe_) {
+      boost::mutex::scoped_lock lock(connection_mutex_);
+      for (size_t i = 0; i < image_publishers_.size(); i++) {
+        image_transport::Publisher pub = image_publishers_[i];
+        if (pub.getNumSubscribers() > 0) {
+          if (!ever_subscribed_) {
+            ever_subscribed_ = true;
+          }
+          if (connection_status_ != SUBSCRIBED) {
+            if (verbose_connection_) {
+              NODELET_INFO("Subscribe input topics");
+            }
+            subscribe();
+            connection_status_ = SUBSCRIBED;
+          }
+          return;
+        }
+      }
+      if (connection_status_ == SUBSCRIBED) {
+        if (verbose_connection_) {
+          NODELET_INFO("Unsubscribe input topics");
+        }
+        unsubscribe();
+        connection_status_ = NOT_SUBSCRIBED;
+      }
+    }
+  }
+
+  void Nodelet::cameraConnectionCallback(
+    const image_transport::SingleSubscriberPublisher& pub)
+  {
+    cameraConnectionBaseCallback();
+  }
+
+  void Nodelet::cameraInfoConnectionCallback(
+    const ros::SingleSubscriberPublisher& pub)
+  {
+    cameraConnectionBaseCallback();
+  }
+
+  void Nodelet::cameraConnectionBaseCallback()
+  {
+    if (verbose_connection_) {
+      NODELET_INFO("New image connection or disconnection is detected");
+    }
+    if (!always_subscribe_) {
+      boost::mutex::scoped_lock lock(connection_mutex_);
+      for (size_t i = 0; i < camera_publishers_.size(); i++) {
+        image_transport::CameraPublisher pub = camera_publishers_[i];
+        if (pub.getNumSubscribers() > 0) {
+          if (!ever_subscribed_) {
+            ever_subscribed_ = true;
+          }
+          if (connection_status_ != SUBSCRIBED) {
+            if (verbose_connection_) {
+              NODELET_INFO("Subscribe input topics");
+            }
+            subscribe();
+            connection_status_ = SUBSCRIBED;
+          }
+          return;
+        }
+      }
+      if (connection_status_ == SUBSCRIBED) {
+        if (verbose_connection_) {
+          NODELET_INFO("Unsubscribe input topics");
+        }
+        unsubscribe();
+        connection_status_ = NOT_SUBSCRIBED;
+      }
+    }
+  }
+}

--- a/opencv_apps/src/nodelet/people_detect_nodelet.cpp
+++ b/opencv_apps/src/nodelet/people_detect_nodelet.cpp
@@ -39,7 +39,7 @@
  */
 
 #include <ros/ros.h>
-#include <nodelet/nodelet.h>
+#include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 
@@ -53,7 +53,7 @@
 #include "opencv_apps/RectArrayStamped.h"
 
 namespace people_detect {
-class PeopleDetectNodelet : public nodelet::Nodelet
+class PeopleDetectNodelet : public opencv_apps::Nodelet
 {
   image_transport::Publisher img_pub_;
   image_transport::Subscriber img_sub_;
@@ -61,13 +61,11 @@ class PeopleDetectNodelet : public nodelet::Nodelet
   ros::Publisher msg_pub_;
 
   boost::shared_ptr<image_transport::ImageTransport> it_;
-  ros::NodeHandle nh_, local_nh_;
 
   people_detect::PeopleDetectConfig config_;
   dynamic_reconfigure::Server<people_detect::PeopleDetectConfig> srv;
 
   bool debug_view_;
-  int subscriber_count_;
   ros::Time prev_stamp_;
 
   std::string window_name_;
@@ -78,11 +76,6 @@ class PeopleDetectNodelet : public nodelet::Nodelet
   void reconfigureCallback(people_detect::PeopleDetectConfig &new_config, uint32_t level)
   {
     config_ = new_config;
-    if (subscriber_count_)
-    { // @todo Could do this without an interruption at some point.
-      unsubscribe();
-      subscribe();
-    }
   }
 
   const std::string &frameWithDefault(const std::string &frame, const std::string &image_frame)
@@ -196,65 +189,30 @@ class PeopleDetectNodelet : public nodelet::Nodelet
     cam_sub_.shutdown();
   }
 
-  void img_connectCb(const image_transport::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void img_disconnectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
-  void msg_connectCb(const ros::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void msg_disconnectCb(const ros::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
 public:
   virtual void onInit()
   {
-    nh_ = getNodeHandle();
-    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
-    local_nh_ = ros::NodeHandle("~");
+    Nodelet::onInit();
+    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(*nh_));
 
-    local_nh_.param("debug_view", debug_view_, false);
-    subscriber_count_ = 0;
+    pnh_->param("debug_view", debug_view_, false);
+    if (debug_view_) {
+      always_subscribe_ = true;
+    }
     prev_stamp_ = ros::Time(0, 0);
 
     window_name_ = "people detector";
 
-    image_transport::SubscriberStatusCallback img_connect_cb    = boost::bind(&PeopleDetectNodelet::img_connectCb, this, _1);
-    image_transport::SubscriberStatusCallback img_disconnect_cb = boost::bind(&PeopleDetectNodelet::img_disconnectCb, this, _1);
-    ros::SubscriberStatusCallback msg_connect_cb    = boost::bind(&PeopleDetectNodelet::msg_connectCb, this, _1);
-    ros::SubscriberStatusCallback msg_disconnect_cb = boost::bind(&PeopleDetectNodelet::msg_disconnectCb, this, _1);
-    img_pub_ = image_transport::ImageTransport(local_nh_).advertise("image", 1, img_connect_cb, img_disconnect_cb);
-    msg_pub_ = local_nh_.advertise<opencv_apps::RectArrayStamped>("found", 1, msg_connect_cb, msg_disconnect_cb);
-        
-    hog_.setSVMDetector(cv::HOGDescriptor::getDefaultPeopleDetector());
-
-    if( debug_view_ ) {
-      subscriber_count_++;
-    }
-
     dynamic_reconfigure::Server<people_detect::PeopleDetectConfig>::CallbackType f =
       boost::bind(&PeopleDetectNodelet::reconfigureCallback, this, _1, _2);
     srv.setCallback(f);
+
+    hog_.setSVMDetector(cv::HOGDescriptor::getDefaultPeopleDetector());
+    
+    img_pub_ = advertiseImage(*pnh_, "image", 1);
+    msg_pub_ = advertise<opencv_apps::RectArrayStamped>(*pnh_, "found", 1);
+
+    onInitPostProcess();
   }
 };
 bool PeopleDetectNodelet::need_config_update_ = false;

--- a/opencv_apps/src/nodelet/phase_corr_nodelet.cpp
+++ b/opencv_apps/src/nodelet/phase_corr_nodelet.cpp
@@ -35,7 +35,7 @@
 // https://github.com/Itseez/opencv/blob/master/samples/cpp/phase_corr.cpp
 
 #include <ros/ros.h>
-#include <nodelet/nodelet.h>
+#include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 
@@ -47,7 +47,7 @@
 #include "opencv_apps/Point2DStamped.h"
 
 namespace phase_corr {
-class PhaseCorrNodelet : public nodelet::Nodelet
+class PhaseCorrNodelet : public opencv_apps::Nodelet
 {
   image_transport::Publisher img_pub_;
   image_transport::Subscriber img_sub_;
@@ -55,13 +55,11 @@ class PhaseCorrNodelet : public nodelet::Nodelet
   ros::Publisher msg_pub_;
 
   boost::shared_ptr<image_transport::ImageTransport> it_;
-  ros::NodeHandle nh_, local_nh_;
 
   phase_corr::PhaseCorrConfig config_;
   dynamic_reconfigure::Server<phase_corr::PhaseCorrConfig> srv;
 
   bool debug_view_;
-  int subscriber_count_;
   ros::Time prev_stamp_;
 
   cv::Mat curr, prev, curr64f, prev64f, hann;
@@ -72,11 +70,6 @@ class PhaseCorrNodelet : public nodelet::Nodelet
   void reconfigureCallback(phase_corr::PhaseCorrConfig &new_config, uint32_t level)
   {
     config_ = new_config;
-    if (subscriber_count_)
-    { // @todo Could do this without an interruption at some point.
-      unsubscribe();
-      subscribe();
-    }
   }
 
   const std::string &frameWithDefault(const std::string &frame, const std::string &image_frame)
@@ -195,63 +188,28 @@ class PhaseCorrNodelet : public nodelet::Nodelet
     cam_sub_.shutdown();
   }
 
-  void img_connectCb(const image_transport::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void img_disconnectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
-  void msg_connectCb(const ros::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void msg_disconnectCb(const ros::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
 public:
   virtual void onInit()
   {
-    nh_ = getNodeHandle();
-    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
-    local_nh_ = ros::NodeHandle("~");
+    Nodelet::onInit();
+    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(*nh_));
 
-    local_nh_.param("debug_view", debug_view_, false);
-    subscriber_count_ = 0;
+    pnh_->param("debug_view", debug_view_, false);
+    if (debug_view_) {
+      always_subscribe_ = true;
+    }
     prev_stamp_ = ros::Time(0, 0);
 
     window_name_ = "phase shift";
-
-    image_transport::SubscriberStatusCallback img_connect_cb    = boost::bind(&PhaseCorrNodelet::img_connectCb, this, _1);
-    image_transport::SubscriberStatusCallback img_disconnect_cb = boost::bind(&PhaseCorrNodelet::img_disconnectCb, this, _1);
-    ros::SubscriberStatusCallback msg_connect_cb    = boost::bind(&PhaseCorrNodelet::msg_connectCb, this, _1);
-    ros::SubscriberStatusCallback msg_disconnect_cb = boost::bind(&PhaseCorrNodelet::msg_disconnectCb, this, _1);
-    img_pub_ = image_transport::ImageTransport(local_nh_).advertise("image", 1, img_connect_cb, img_disconnect_cb);
-    msg_pub_ = local_nh_.advertise<opencv_apps::Point2DStamped>("shift", 1, msg_connect_cb, msg_disconnect_cb);
-
-    if( debug_view_ ) {
-      subscriber_count_++;
-    }
-
+    
     dynamic_reconfigure::Server<phase_corr::PhaseCorrConfig>::CallbackType f =
       boost::bind(&PhaseCorrNodelet::reconfigureCallback, this, _1, _2);
     srv.setCallback(f);
+
+    img_pub_ = advertiseImage(*pnh_, "image", 1);
+    msg_pub_ = advertise<opencv_apps::Point2DStamped>(*pnh_, "shift", 1);
+
+    onInitPostProcess();
   }
 };
 bool PhaseCorrNodelet::need_config_update_ = false;

--- a/opencv_apps/src/nodelet/segment_objects_nodelet.cpp
+++ b/opencv_apps/src/nodelet/segment_objects_nodelet.cpp
@@ -38,7 +38,7 @@
  */
 
 #include <ros/ros.h>
-#include <nodelet/nodelet.h>
+#include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 
@@ -55,7 +55,7 @@
 #include "opencv_apps/ContourArrayStamped.h"
 
 namespace segment_objects {
-class SegmentObjectsNodelet : public nodelet::Nodelet
+class SegmentObjectsNodelet : public opencv_apps::Nodelet
 {
   image_transport::Publisher img_pub_;
   image_transport::Subscriber img_sub_;
@@ -64,13 +64,11 @@ class SegmentObjectsNodelet : public nodelet::Nodelet
   ros::ServiceServer update_bg_model_service_;
 
   boost::shared_ptr<image_transport::ImageTransport> it_;
-  ros::NodeHandle nh_, local_nh_;
 
   segment_objects::SegmentObjectsConfig config_;
   dynamic_reconfigure::Server<segment_objects::SegmentObjectsConfig> srv;
 
   bool debug_view_;
-  int subscriber_count_;
   ros::Time prev_stamp_;
 
   std::string window_name_;
@@ -86,11 +84,6 @@ class SegmentObjectsNodelet : public nodelet::Nodelet
   void reconfigureCallback(segment_objects::SegmentObjectsConfig &new_config, uint32_t level)
   {
     config_ = new_config;
-    if (subscriber_count_)
-    { // @todo Could do this without an interruption at some point.
-      unsubscribe();
-      subscribe();
-    }
   }
 
   const std::string &frameWithDefault(const std::string &frame, const std::string &image_frame)
@@ -243,45 +236,16 @@ class SegmentObjectsNodelet : public nodelet::Nodelet
     cam_sub_.shutdown();
   }
 
-  void img_connectCb(const image_transport::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void img_disconnectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
-  void msg_connectCb(const ros::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void msg_disconnectCb(const ros::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
 public:
   virtual void onInit()
   {
-    nh_ = getNodeHandle();
-    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
-    local_nh_ = ros::NodeHandle("~");
+    Nodelet::onInit();
+    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(*nh_));
 
-    local_nh_.param("debug_view", debug_view_, false);
-    subscriber_count_ = 0;
+    pnh_->param("debug_view", debug_view_, false);
+    if (debug_view_) {
+      always_subscribe_ = true;
+    }
     prev_stamp_ = ros::Time(0, 0);
 
     window_name_ = "segmented";
@@ -293,22 +257,16 @@ public:
     bgsubtractor.set("noiseSigma", 10);
 #endif
 
-    image_transport::SubscriberStatusCallback img_connect_cb    = boost::bind(&SegmentObjectsNodelet::img_connectCb, this, _1);
-    image_transport::SubscriberStatusCallback img_disconnect_cb = boost::bind(&SegmentObjectsNodelet::img_disconnectCb, this, _1);
-    ros::SubscriberStatusCallback msg_connect_cb    = boost::bind(&SegmentObjectsNodelet::msg_connectCb, this, _1);
-    ros::SubscriberStatusCallback msg_disconnect_cb = boost::bind(&SegmentObjectsNodelet::msg_disconnectCb, this, _1);
-    img_pub_ = image_transport::ImageTransport(local_nh_).advertise("image", 1, img_connect_cb, img_disconnect_cb);
-    msg_pub_ = local_nh_.advertise<opencv_apps::ContourArrayStamped>("contours", 1, msg_connect_cb, msg_disconnect_cb);
-    area_pub_ = local_nh_.advertise<std_msgs::Float64>("area", 1, msg_connect_cb, msg_disconnect_cb);
-    update_bg_model_service_ = local_nh_.advertiseService("update_bg_model", &SegmentObjectsNodelet::update_bg_model_cb, this);
-        
-    if( debug_view_ ) {
-      subscriber_count_++;
-    }
-
     dynamic_reconfigure::Server<segment_objects::SegmentObjectsConfig>::CallbackType f =
       boost::bind(&SegmentObjectsNodelet::reconfigureCallback, this, _1, _2);
     srv.setCallback(f);
+    
+    img_pub_ = advertiseImage(*pnh_, "image", 1);
+    msg_pub_ = advertise<opencv_apps::ContourArrayStamped>(*pnh_, "contours", 1);
+    area_pub_ = advertise<std_msgs::Float64>(*pnh_, "area", 1);
+    update_bg_model_service_ = pnh_->advertiseService("update_bg_model", &SegmentObjectsNodelet::update_bg_model_cb, this);
+
+    onInitPostProcess();
   }
 };
 bool SegmentObjectsNodelet::need_config_update_ = false;

--- a/opencv_apps/src/nodelet/watershed_segmentation_nodelet.cpp
+++ b/opencv_apps/src/nodelet/watershed_segmentation_nodelet.cpp
@@ -38,7 +38,7 @@
  */
 
 #include <ros/ros.h>
-#include <nodelet/nodelet.h>
+#include "opencv_apps/nodelet.h"
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 
@@ -53,7 +53,7 @@
 #include "opencv_apps/Point2DArray.h"
 
 namespace watershed_segmentation {
-class WatershedSegmentationNodelet : public nodelet::Nodelet
+class WatershedSegmentationNodelet : public opencv_apps::Nodelet
 {
   image_transport::Publisher img_pub_;
   image_transport::Subscriber img_sub_;
@@ -62,13 +62,11 @@ class WatershedSegmentationNodelet : public nodelet::Nodelet
   ros::Subscriber add_seed_points_sub_;
 
   boost::shared_ptr<image_transport::ImageTransport> it_;
-  ros::NodeHandle nh_, local_nh_;
 
   watershed_segmentation::WatershedSegmentationConfig config_;
   dynamic_reconfigure::Server<watershed_segmentation::WatershedSegmentationConfig> srv;
 
   bool debug_view_;
-  int subscriber_count_;
   ros::Time prev_stamp_;
 
   std::string window_name_, segment_name_;
@@ -94,11 +92,6 @@ class WatershedSegmentationNodelet : public nodelet::Nodelet
   void reconfigureCallback(watershed_segmentation::WatershedSegmentationConfig &new_config, uint32_t level)
   {
     config_ = new_config;
-    if (subscriber_count_)
-    { // @todo Could do this without an interruption at some point.
-      unsubscribe();
-      subscribe();
-    }
   }
 
   const std::string &frameWithDefault(const std::string &frame, const std::string &image_frame)
@@ -297,45 +290,16 @@ class WatershedSegmentationNodelet : public nodelet::Nodelet
     cam_sub_.shutdown();
   }
 
-  void img_connectCb(const image_transport::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void img_disconnectCb(const image_transport::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
-  void msg_connectCb(const ros::SingleSubscriberPublisher& ssp)
-  {
-    if (subscriber_count_++ == 0) {
-      subscribe();
-    }
-  }
-
-  void msg_disconnectCb(const ros::SingleSubscriberPublisher&)
-  {
-    subscriber_count_--;
-    if (subscriber_count_ == 0) {
-      unsubscribe();
-    }
-  }
-
 public:
   virtual void onInit()
   {
-    nh_ = getNodeHandle();
-    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh_));
-    local_nh_ = ros::NodeHandle("~");
+    Nodelet::onInit();
+    it_ = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(*nh_));
 
-    local_nh_.param("debug_view", debug_view_, false);
-    subscriber_count_ = 0;
+    pnh_->param("debug_view", debug_view_, false);
+    if (debug_view_) {
+      always_subscribe_ = true;
+    }
     prev_stamp_ = ros::Time(0, 0);
 
     window_name_ = "roughly mark the areas to segment on the image";
@@ -343,21 +307,14 @@ public:
     prevPt.x = -1;
     prevPt.y = -1;
 
-    image_transport::SubscriberStatusCallback img_connect_cb    = boost::bind(&WatershedSegmentationNodelet::img_connectCb, this, _1);
-    image_transport::SubscriberStatusCallback img_disconnect_cb = boost::bind(&WatershedSegmentationNodelet::img_disconnectCb, this, _1);
-    ros::SubscriberStatusCallback msg_connect_cb    = boost::bind(&WatershedSegmentationNodelet::msg_connectCb, this, _1);
-    ros::SubscriberStatusCallback msg_disconnect_cb = boost::bind(&WatershedSegmentationNodelet::msg_disconnectCb, this, _1);
-    img_pub_ = image_transport::ImageTransport(local_nh_).advertise("image", 1, img_connect_cb, img_disconnect_cb);
-    msg_pub_ = local_nh_.advertise<opencv_apps::ContourArrayStamped>("contours", 1, msg_connect_cb, msg_disconnect_cb);
-    add_seed_points_sub_ = local_nh_.subscribe("add_seed_points", 1, &WatershedSegmentationNodelet::add_seed_point_cb, this);
-        
-    if( debug_view_ ) {
-      subscriber_count_++;
-    }
-
     dynamic_reconfigure::Server<watershed_segmentation::WatershedSegmentationConfig>::CallbackType f =
       boost::bind(&WatershedSegmentationNodelet::reconfigureCallback, this, _1, _2);
     srv.setCallback(f);
+
+    add_seed_points_sub_ = pnh_->subscribe("add_seed_points", 1, &WatershedSegmentationNodelet::add_seed_point_cb, this);
+    img_pub_ = advertiseImage(*pnh_, "image", 1);
+    msg_pub_ = advertise<opencv_apps::ContourArrayStamped>(*pnh_, "contours", 1);
+    
 
     NODELET_INFO("This program demonstrates the famous watershed segmentation algorithm in OpenCV: watershed()");
     NODELET_INFO("Hot keys: ");
@@ -366,6 +323,8 @@ public:
     NODELET_INFO("\tw or SPACE - run watershed segmentation algorithm");
     NODELET_INFO("\t\t(before running it, *roughly* mark the areas to segment on the image)");
     NODELET_INFO("\t  (before that, roughly outline several markers on the image)");
+
+    onInitPostProcess();
   }
 };
 bool WatershedSegmentationNodelet::need_config_update_ = false;


### PR DESCRIPTION
1. Add opencv_apps::Nodelet class to handle connection and disconnection of
   topics.
2. Update nodelets of opencv_apps to inhereit opencv_apps::Nodelet class
   to remove duplicated codes.
