### PR TITLE
geometry_msgs doesn't get used by opencv_apps, but std_msgs does.

### DIFF
--- a/opencv_apps/CMakeLists.txt
+++ b/opencv_apps/CMakeLists.txt
@@ -66,10 +66,14 @@ add_message_files(
 ## Generate added messages and services with any dependencies listed here
 generate_messages(
   DEPENDENCIES
-  geometry_msgs
+  std_msgs
 )
 
-catkin_package()
+catkin_package(CATKIN_DEPENDS std_msgs
+#                DEPENDS OpenCV
+               INCLUDE_DIRS include
+               LIBRARIES ${PROJECT_NAME}
+)
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 

--- a/opencv_apps/package.xml
+++ b/opencv_apps/package.xml
@@ -17,6 +17,7 @@
   <build_depend>message_generation</build_depend>
   <build_depend>nodelet</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
 
   <run_depend>cv_bridge</run_depend>
@@ -25,6 +26,7 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>std_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
 
   <test_depend>rostest</test_depend>


### PR DESCRIPTION
I tried making a package that used opencv_apps msgs, but then the build complained about geometry_msgs, which I thought opencv_apps ought to be putting into catkin_package()- but it looks like it doesn't need it at all.
