### PR TITLE
Add fullResolution getter to python PinholeCameraModel

### DIFF
--- a/image_geometry/src/image_geometry/cameramodels.py
+++ b/image_geometry/src/image_geometry/cameramodels.py
@@ -52,6 +52,8 @@ class PinholeCameraModel:
         self.height = msg.height
         self.binning_x = max(1, msg.binning_x)
         self.binning_y = max(1, msg.binning_y)
+        self.resolution = (msg.width, msg.height)
+
         self.raw_roi = copy.copy(msg.roi)
         # ROI all zeros is considered the same as full resolution
         if (self.raw_roi.x_offset == 0 and self.raw_roi.y_offset == 0 and
@@ -201,6 +203,10 @@ class PinholeCameraModel:
         """
         fy = self.P[1, 1]
         return Z * deltaV / fy
+
+    def fullResolution(self):
+        """Returns the full resolution of the camera"""
+        return self.resolution
 
     def intrinsicMatrix(self):
         """ Returns :math:`K`, also called camera_matrix in cv docs """


### PR DESCRIPTION
A feature often useful in C++, but not available in Python

Also, would a PR for improving numpy support be welcome? [Here's the kludge](https://github.com/uf-mil/Sub8/blob/master/gnc/sub8_perception/sub8_vision_tools/estimation.py#L164) I've resorted to elsewhere.

Love, Jake
