### PR TITLE
Fix compilation of cv_bridge with opencv3 and python3.

### DIFF
--- a/cv_bridge/src/module_opencv3.cpp
+++ b/cv_bridge/src/module_opencv3.cpp
@@ -6,6 +6,7 @@
 
 #include "opencv2/opencv_modules.hpp"
 
+#include "pycompat.hpp"
 
 static PyObject* opencv_error = 0;
 

--- a/cv_bridge/src/pycompat.hpp
+++ b/cv_bridge/src/pycompat.hpp
@@ -1,0 +1,70 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+// Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+// Defines for Python 2/3 compatibility.
+#ifndef __PYCOMPAT_HPP__
+#define __PYCOMPAT_HPP__
+
+#if PY_MAJOR_VERSION >= 3
+// Python3 treats all ints as longs, PyInt_X functions have been removed.
+#define PyInt_Check PyLong_Check
+#define PyInt_CheckExact PyLong_CheckExact
+#define PyInt_AsLong PyLong_AsLong
+#define PyInt_AS_LONG PyLong_AS_LONG
+#define PyInt_FromLong PyLong_FromLong
+#define PyNumber_Int PyNumber_Long
+
+// Python3 strings are unicode, these defines mimic the Python2 functionality.
+#define PyString_Check PyUnicode_Check
+#define PyString_FromString PyUnicode_FromString
+#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
+#define PyString_Size PyUnicode_GET_SIZE
+
+// PyUnicode_AsUTF8 isn't available until Python 3.3
+#if (PY_VERSION_HEX < 0x03030000)
+#define PyString_AsString _PyUnicode_AsString
+#else
+#define PyString_AsString PyUnicode_AsUTF8
+#endif
+#endif
+
+#endif // END HEADER GUARD


### PR DESCRIPTION
This PR fixed compilation of cv_bridge with opencv3 and python3.

The Int type from python2 no longer exists in python3, only the Long type remains. The suggested fix here [1] is to alias `PyInt_*` to `PyLong_*`, so that is what I did. Maybe it would be fine to use `PyLong` in python2 too, but I don't know if that is the case, so I went for this approach instead.

[1] https://wiki.python.org/moin/PortingExtensionModulesToPy3k
