### PR TITLE
[cv_bridge] Add python binding for cv_bridge::cvtColorForDisplay

### DIFF
--- a/cv_bridge/python/cv_bridge/__init__.py
+++ b/cv_bridge/python/cv_bridge/__init__.py
@@ -1,1 +1,4 @@
 from .core import CvBridge, CvBridgeError
+
+# python bindings
+from cv_bridge.boost.cv_bridge_boost import cvtColorForDisplay

--- a/cv_bridge/src/module.cpp
+++ b/cv_bridge/src/module.cpp
@@ -50,6 +50,30 @@ cvtColor2Wrap(bp::object obj_in, const std::string & encoding_in, const std::str
   return bp::object(boost::python::handle<>(pyopencv_from(mat)));
 }
 
+bp::object
+cvtColorForDisplayWrap(bp::object obj_in,
+                       const std::string & encoding_in,
+                       const std::string & encoding_out,
+                       bool do_dynamic_scaling = false,
+                       double min_image_value = 0.0,
+                       double max_image_value = 0.0) {
+  // Convert the Python input to an image
+  cv::Mat mat_in;
+  convert_to_CvMat2(obj_in.ptr(), mat_in);
+
+  cv_bridge::CvImagePtr cv_image(new cv_bridge::CvImage(std_msgs::Header(), encoding_in, mat_in));
+
+  cv::Mat mat = cv_bridge::cvtColorForDisplay(/*source=*/cv_image,
+                                              /*encoding_out=*/encoding_out,
+                                              /*do_dynamic_scaling=*/do_dynamic_scaling,
+                                              /*min_image_value=*/min_image_value,
+                                              /*max_image_value=*/max_image_value)->image;
+
+  return bp::object(boost::python::handle<>(pyopencv_from(mat)));
+}
+
+BOOST_PYTHON_FUNCTION_OVERLOADS(cvtColorForDisplayWrap_overloads, cvtColorForDisplayWrap, 3, 6)
+
 BOOST_PYTHON_MODULE(cv_bridge_boost)
 {
   do_numpy_import();
@@ -58,4 +82,17 @@ BOOST_PYTHON_MODULE(cv_bridge_boost)
   // Wrap the function to get encodings as OpenCV types
   boost::python::def("getCvType", cv_bridge::getCvType);
   boost::python::def("cvtColor2", cvtColor2Wrap);
+  boost::python::def("cvtColorForDisplay", cvtColorForDisplayWrap,
+                     cvtColorForDisplayWrap_overloads(
+                       boost::python::args("source", "encoding_in", "encoding_out", "do_dynamic_scaling",
+                                           "min_image_value", "max_image_value"),
+                       "Convert image to display with specified encodings.\n\n"
+                       "Args:\n"
+                       "  - source (numpy.ndarray): input image\n"
+                       "  - encoding_in (str): input image encoding\n"
+                       "  - encoding_out (str): encoding to which the image conveted\n"
+                       "  - do_dynamic_scaling (bool): flag to do dynamic scaling with min/max value\n"
+                       "  - min_image_value (float): minimum pixel value for dynamic scaling\n"
+                       "  - max_image_value (float): maximum pixel value for dynamic scaling\n"
+                     ));
 }

--- a/cv_bridge/test/CMakeLists.txt
+++ b/cv_bridge/test/CMakeLists.txt
@@ -11,3 +11,4 @@ target_link_libraries(${PROJECT_NAME}-utest
 )
 
 catkin_add_nosetests(enumerants.py)
+catkin_add_nosetests(python_bindings.py)

--- a/cv_bridge/test/python_bindings.py
+++ b/cv_bridge/test/python_bindings.py
@@ -1,0 +1,26 @@
+from nose.tools import assert_equal
+import numpy as np
+
+import cv_bridge
+
+
+def test_cvtColorForDisplay():
+    # convert label image to display
+    label = np.zeros((480, 640), dtype=np.int32)
+    height, width = label.shape[:2]
+    label_value = 0
+    grid_num_y, grid_num_x = 3, 4
+    for grid_row in xrange(grid_num_y):
+        grid_size_y = height / grid_num_y
+        min_y = grid_size_y * grid_row
+        max_y = min_y + grid_size_y
+        for grid_col in xrange(grid_num_x):
+            grid_size_x = width / grid_num_x
+            min_x = grid_size_x * grid_col
+            max_x = min_x + grid_size_x
+            label[min_y:max_y, min_x:max_x] = label_value
+            label_value += 1
+    label_viz = cv_bridge.cvtColorForDisplay(label, '32SC1', 'bgr8')
+    assert_equal(label_viz.dtype, np.uint8)
+    assert_equal(label_viz.min(), 0)
+    assert_equal(label_viz.max(), 255)


### PR DESCRIPTION
For https://github.com/ros-perception/image_pipeline/pull/174#issuecomment-170364629
