### PR TITLE
Support compressed Images messages in python for indigo

### DIFF
--- a/opencv_tests/nodes/broadcast_compressed.py
+++ b/opencv_tests/nodes/broadcast_compressed.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2008, Willow Garage, Inc.
+# Copyright (c) 2016, Tal Regev.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the Willow Garage nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+import time
+import math
+import rospy
+import cv2
+
+import sensor_msgs.msg
+from cv_bridge import CvBridge
+
+class source:
+
+  def __init__(self, topic, filenames):
+    self.pub = rospy.Publisher(topic, sensor_msgs.msg.CompressedImage)
+    self.filenames = filenames
+
+  def spin(self):
+    time.sleep(1.0)
+    cvb = CvBridge()
+    while not rospy.core.is_shutdown():
+      cvim = cv2.imload(self.filenames[0])
+      self.pub.publish(cvb.cv2_to_compressed_imgmsg(cvim))
+      self.filenames = self.filenames[1:] + [self.filenames[0]]
+      time.sleep(1)
+
+def main(args):
+  s = source(args[1], args[2:])
+  rospy.init_node('source')
+  try:
+    s.spin()
+    rospy.spin()
+    outcome = 'test completed'
+  except KeyboardInterrupt:
+    print "shutting down"
+    outcome = 'keyboard interrupt'
+  rospy.core.signal_shutdown(outcome)
+
+if __name__ == '__main__':
+  main(sys.argv)

--- a/opencv_tests/nodes/rosfacedetect_compressed.py
+++ b/opencv_tests/nodes/rosfacedetect_compressed.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+"""
+This program is demonstration for face and object detection using haar-like features.
+The program finds faces in a camera image or video stream and displays a red box around them.
+
+Original C implementation by:  ?
+Python implementation by: Roman Stanchak, James Bowman
+Updated: Copyright (c) 2016, Tal Regev.
+"""
+
+import sys
+import os
+from optparse import OptionParser
+
+import rospy
+import sensor_msgs.msg
+from cv_bridge import CvBridge
+import cv2
+import numpy
+
+# Parameters for haar detection
+# From the API:
+# The default parameters (scale_factor=2, min_neighbors=3, flags=0) are tuned 
+# for accurate yet slow object detection. For a faster operation on real video 
+# images the settings are: 
+# scale_factor=1.2, min_neighbors=2, flags=CV_HAAR_DO_CANNY_PRUNING, 
+# min_size=<minimum possible face size
+
+min_size = (10, 10)
+image_scale = 2
+haar_scale = 1.2
+min_neighbors = 2
+haar_flags = 0
+
+if __name__ == '__main__':
+
+    haarfile = '/usr/share/opencv/haarcascades/haarcascade_frontalface_alt.xml'
+
+    parser = OptionParser(usage = "usage: %prog [options]")
+    parser.add_option("-c", "--cascade", action="store", dest="cascade", type="str", help="Haar cascade file, default %default", default = haarfile)
+    parser.add_option("-t", "--topic", action="store", dest="topic", type="str", help="Topic to find a face on, default %default", default = '/camera/rgb/image_raw')
+    (options, args) = parser.parse_args()
+
+    cascade = cv2.CascadeClassifier()
+    cascade.load(options.cascade)
+    br = CvBridge()
+
+    def detect_and_draw(compressed_imgmsg):
+        img = br.compressed_imgmsg_to_cv2(compressed_imgmsg, "bgr8")
+        # allocate temporary images
+        new_size = (int(img.shape[1] / image_scale), int(img.shape[0] / image_scale))
+
+        # convert color input image to grayscale
+        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+
+        # scale input image for faster processing
+        small_img = cv2.resize(gray, new_size, interpolation = cv2.INTER_LINEAR)
+
+        small_img = cv2.equalizeHist(small_img)
+
+        if(cascade):
+            faces = cascade.detectMultiScale(small_img, haar_scale, min_neighbors, haar_flags, min_size)
+            if faces is not None:
+                for (x, y, w, h) in faces:
+                    # the input to detectMultiScale was resized, so scale the 
+                    # bounding box of each face and convert it to two CvPoints
+                    pt1 = (int(x * image_scale), int(y * image_scale))
+                    pt2 = (int((x + w) * image_scale), int((y + h) * image_scale))
+                    cv2.rectangle(img, pt1, pt2, (255, 0, 0), 3, 8, 0)
+
+        cv2.imshow("result", img)
+        cv2.waitKey(6)
+
+    rospy.init_node('rosfacedetect')
+    rospy.Subscriber(options.topic, sensor_msgs.msg.CompressedImage, detect_and_draw)
+    rospy.spin()

--- a/opencv_tests/nodes/source_compressed.py
+++ b/opencv_tests/nodes/source_compressed.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2008, Willow Garage, Inc.
+# Copyright (c) 2016, Tal Regev.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the Willow Garage nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+import time
+import math
+import rospy
+import numpy
+import cv2
+
+import sensor_msgs.msg
+from cv_bridge import CvBridge
+
+class source:
+
+  def __init__(self):
+    self.pub = rospy.Publisher("/opencv_tests/images/compressed", sensor_msgs.msg.CompressedImage)
+
+  def spin(self):
+    time.sleep(1.0)
+    started = time.time()
+    counter = 0
+    cvim = numpy.zeros((480, 640, 1), numpy.uint8)
+    ball_xv = 10
+    ball_yv = 10
+    ball_x = 100
+    ball_y = 100
+
+    cvb = CvBridge()
+
+    while not rospy.core.is_shutdown():
+
+      cvim.fill(0)
+      cv2.circle(cvim, (ball_x, ball_y), 10, 255, -1)
+
+      ball_x += ball_xv
+      ball_y += ball_yv
+      if ball_x in [10, 630]:
+        ball_xv = -ball_xv
+      if ball_y in [10, 470]:
+        ball_yv = -ball_yv
+
+      self.pub.publish(cvb.cv2_to_compressed_imgmsg(cvim))
+      time.sleep(0.03)
+
+def main(args):
+  s = source()
+  rospy.init_node('source')
+  try:
+    s.spin()
+    rospy.spin()
+    outcome = 'test completed'
+  except KeyboardInterrupt:
+    print "shutting down"
+    outcome = 'keyboard interrupt'
+  rospy.core.signal_shutdown(outcome)
+
+if __name__ == '__main__':
+  main(sys.argv)


### PR DESCRIPTION
- Add cv2_to_comprssed_imgmsg: Convert from cv2 image to compressed image ros msg.
- Add comprssed_imgmsg_to_cv2:   Convert the compress message to a new image.
- Add compressed image tests.
- Add time to msgs (compressed and regular).
