### PR TITLE
Support compressed Images messages in python for indigo

### DIFF
--- a/cv_bridge/include/cv_bridge/cv_bridge.h
+++ b/cv_bridge/include/cv_bridge/cv_bridge.h
@@ -60,7 +60,7 @@ typedef boost::shared_ptr<CvImage const> CvImageConstPtr;
 
 //from: http://docs.opencv.org/modules/highgui/doc/reading_and_writing_images_and_video.html#Mat imread(const string& filename, int flags)
 typedef enum {
-	BMP, DIP,
+	BMP, DIB,
 	JPG, JPEG, JPE,
 	JP2,
 	PNG,

--- a/cv_bridge/src/cv_bridge.cpp
+++ b/cv_bridge/src/cv_bridge.cpp
@@ -431,7 +431,7 @@ cv::Mat matFromImage(const sensor_msgs::CompressedImage& source)
     cv::Mat jpegData(1,source.data.size(),CV_8UC1);
     jpegData.data     = const_cast<uchar*>(&source.data[0]);
     cv::InputArray data(jpegData);
-    cv::Mat bgrMat     = cv::imdecode(data,cv::IMREAD_COLOR);
+    cv::Mat bgrMat     = cv::imdecode(data,cv::IMREAD_ANYCOLOR);
     return bgrMat;
 }
 
@@ -445,8 +445,8 @@ sensor_msgs::CompressedImagePtr CvImage::toCompressedImageMsg(const Format dst_f
 std::string getFormat(Format format) {
 
 	switch (format) {
-		case DIP:
-			return "dip";
+		case DIB:
+			return "dib";
 		case BMP:
 			return "bmp";
 		case JPG:

--- a/cv_bridge/test/enumerants.py
+++ b/cv_bridge/test/enumerants.py
@@ -6,6 +6,7 @@ import sensor_msgs.msg
 
 from cv_bridge import CvBridge, CvBridgeError
 
+
 class TestEnumerants(unittest.TestCase):
 
     def test_enumerants_cv2(self):
@@ -31,7 +32,7 @@ class TestEnumerants(unittest.TestCase):
     def test_encode_decode_cv2(self):
         import cv2
         import numpy as np
-        fmts = [ cv2.CV_8U, cv2.CV_8S, cv2.CV_16U, cv2.CV_16S, cv2.CV_32S, cv2.CV_32F, cv2.CV_64F ]
+        fmts = [cv2.CV_8U, cv2.CV_8S, cv2.CV_16U, cv2.CV_16S, cv2.CV_32S, cv2.CV_32F, cv2.CV_64F]
 
         cvb_en = CvBridge()
         cvb_de = CvBridge()
@@ -39,13 +40,41 @@ class TestEnumerants(unittest.TestCase):
         for w in range(100, 800, 100):
             for h in range(100, 800, 100):
                 for f in fmts:
-                    for channels in ([],1,2,3,4):
+                    for channels in ([], 1, 2, 3, 4):
                         if channels == []:
                             original = np.uint8(np.random.randint(0, 255, size=(h, w)))
                         else:
                             original = np.uint8(np.random.randint(0, 255, size=(h, w, channels)))
                         rosmsg = cvb_en.cv2_to_imgmsg(original)
                         newimg = cvb_de.imgmsg_to_cv2(rosmsg)
+
+                        self.assert_(original.dtype == newimg.dtype)
+                        if channels == 1:
+                            # in that case, a gray image has a shape of size 2
+                            self.assert_(original.shape[:2] == newimg.shape[:2])
+                        else:
+                            self.assert_(original.shape == newimg.shape)
+                        self.assert_(len(original.tostring()) == len(newimg.tostring()))
+
+    def test_encode_decode_cv2_compressed(self):
+        import numpy as np
+        # from: http://docs.opencv.org/2.4/modules/highgui/doc/reading_and_writing_images_and_video.html#Mat imread(const string& filename, int flags)
+        formats = ["jpg", "jpeg", "jpe", "png", "bmp", "dib", "ppm", "pgm", "pbm",
+                   "jp2", "sr", "ras", "tif", "tiff"]  # this formats rviz is not support
+
+        cvb_en = CvBridge()
+        cvb_de = CvBridge()
+
+        for w in range(100, 800, 100):
+            for h in range(100, 800, 100):
+                for f in formats:
+                    for channels in ([], 1, 3):
+                        if channels == []:
+                            original = np.uint8(np.random.randint(0, 255, size=(h, w)))
+                        else:
+                            original = np.uint8(np.random.randint(0, 255, size=(h, w, channels)))
+                        compress_rosmsg = cvb_en.cv2_to_compressed_imgmsg(original, f)
+                        newimg          = cvb_de.compressed_imgmsg_to_cv2(compress_rosmsg)
                         self.assert_(original.dtype == newimg.dtype)
                         if channels == 1:
                             # in that case, a gray image has a shape of size 2
@@ -64,8 +93,8 @@ class TestEnumerants(unittest.TestCase):
 
     def test_mono16_cv2(self):
         import numpy as np
-        br = CvBridge()
-        im = np.uint8(np.random.randint(0, 255, size=(480, 640, 3)))
+        br  = CvBridge()
+        im  = np.uint8(np.random.randint(0, 255, size=(480, 640, 3)))
         msg = br.cv2_to_imgmsg(im)
 
 if __name__ == '__main__':

--- a/opencv_tests/nodes/broadcast.py
+++ b/opencv_tests/nodes/broadcast.py
@@ -2,6 +2,7 @@
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2008, Willow Garage, Inc.
+# Copyright (c) 2016, Tal Regev.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -40,32 +41,38 @@ import cv2
 import sensor_msgs.msg
 from cv_bridge import CvBridge
 
-class source:
 
-  def __init__(self, topic, filenames):
-    self.pub = rospy.Publisher(topic, sensor_msgs.msg.Image)
-    self.filenames = filenames
+# Send each image by iterate it from given array of files names  to a given topic,
+# as a regular and compressed ROS Images msgs.
+class Source:
 
-  def spin(self):
-    time.sleep(1.0)
-    cvb = CvBridge()
-    while not rospy.core.is_shutdown():
-      cvim = cv2.imload(self.filenames[0])
-      self.pub.publish(cvb.cv2_to_imgmsg(cvim))
-      self.filenames = self.filenames[1:] + [self.filenames[0]]
-      time.sleep(1)
+    def __init__(self, topic, filenames):
+        self.pub            = rospy.Publisher(topic, sensor_msgs.msg.Image)
+        self.pub_compressed = rospy.Publisher(topic + "/compressed", sensor_msgs.msg.CompressedImage)
+        self.filenames      = filenames
+
+    def spin(self):
+        time.sleep(1.0)
+        cvb = CvBridge()
+        while not rospy.core.is_shutdown():
+            cvim = cv2.imload(self.filenames[0])
+            self.pub.publish(cvb.cv2_to_imgmsg(cvim))
+            self.pub_compressed.publish(cvb.cv2_to_compressed_imgmsg(cvim))
+            self.filenames = self.filenames[1:] + [self.filenames[0]]
+            time.sleep(1)
+
 
 def main(args):
-  s = source(args[1], args[2:])
-  rospy.init_node('source')
-  try:
-    s.spin()
-    rospy.spin()
-    outcome = 'test completed'
-  except KeyboardInterrupt:
-    print "shutting down"
-    outcome = 'keyboard interrupt'
-  rospy.core.signal_shutdown(outcome)
+    s = Source(args[1], args[2:])
+    rospy.init_node('Source')
+    try:
+        s.spin()
+        rospy.spin()
+        outcome = 'test completed'
+    except KeyboardInterrupt:
+        print "shutting down"
+        outcome = 'keyboard interrupt'
+    rospy.core.signal_shutdown(outcome)
 
 if __name__ == '__main__':
-  main(sys.argv)
+    main(sys.argv)

--- a/opencv_tests/nodes/rosfacedetect.py
+++ b/opencv_tests/nodes/rosfacedetect.py
@@ -5,6 +5,7 @@ The program finds faces in a camera image or video stream and displays a red box
 
 Original C implementation by:  ?
 Python implementation by: Roman Stanchak, James Bowman
+Updated: Copyright (c) 2016, Tal Regev.
 """
 
 import sys
@@ -19,25 +20,27 @@ import numpy
 
 # Parameters for haar detection
 # From the API:
-# The default parameters (scale_factor=2, min_neighbors=3, flags=0) are tuned 
-# for accurate yet slow object detection. For a faster operation on real video 
-# images the settings are: 
-# scale_factor=1.2, min_neighbors=2, flags=CV_HAAR_DO_CANNY_PRUNING, 
+# The default parameters (scale_factor=2, min_neighbors=3, flags=0) are tuned
+# for accurate yet slow object detection. For a faster operation on real video
+# images the settings are:
+# scale_factor=1.2, min_neighbors=2, flags=CV_HAAR_DO_CANNY_PRUNING,
 # min_size=<minimum possible face size
 
-min_size = (10, 10)
-image_scale = 2
-haar_scale = 1.2
+min_size      = (10, 10)
+image_scale   = 2
+haar_scale    = 1.2
 min_neighbors = 2
-haar_flags = 0
+haar_flags    = 0
 
 if __name__ == '__main__':
 
+    # TODO add this file in the repository and make it relative to this python script. (not all people will run this from linux)
     haarfile = '/usr/share/opencv/haarcascades/haarcascade_frontalface_alt.xml'
 
     parser = OptionParser(usage = "usage: %prog [options]")
     parser.add_option("-c", "--cascade", action="store", dest="cascade", type="str", help="Haar cascade file, default %default", default = haarfile)
     parser.add_option("-t", "--topic", action="store", dest="topic", type="str", help="Topic to find a face on, default %default", default = '/camera/rgb/image_raw')
+    parser.add_option("-ct", "--ctopic", action="store", dest="ctopic", type="str", help="Compressed topic to find a face on, default %default", default = '/camera/rgb/image/compressed')
     (options, args) = parser.parse_args()
 
     cascade = cv2.CascadeClassifier()
@@ -61,7 +64,7 @@ if __name__ == '__main__':
             faces = cascade.detectMultiScale(small_img, haar_scale, min_neighbors, haar_flags, min_size)
             if faces is not None:
                 for (x, y, w, h) in faces:
-                    # the input to detectMultiScale was resized, so scale the 
+                    # the input to detectMultiScale was resized, so scale the
                     # bounding box of each face and convert it to two CvPoints
                     pt1 = (int(x * image_scale), int(y * image_scale))
                     pt2 = (int((x + w) * image_scale), int((y + h) * image_scale))
@@ -70,6 +73,33 @@ if __name__ == '__main__':
         cv2.imshow("result", img)
         cv2.waitKey(6)
 
+    def compressed_detect_and_draw(compressed_imgmsg):
+        img = br.compressed_imgmsg_to_cv2(compressed_imgmsg, "bgr8")
+        # allocate temporary images
+        new_size = (int(img.shape[1] / image_scale), int(img.shape[0] / image_scale))
+
+        # convert color input image to grayscale
+        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+
+        # scale input image for faster processing
+        small_img = cv2.resize(gray, new_size, interpolation = cv2.INTER_LINEAR)
+
+        small_img = cv2.equalizeHist(small_img)
+
+        if(cascade):
+            faces = cascade.detectMultiScale(small_img, haar_scale, min_neighbors, haar_flags, min_size)
+            if faces is not None:
+                for (x, y, w, h) in faces:
+                    # the input to detectMultiScale was resized, so scale the
+                    # bounding box of each face and convert it to two CvPoints
+                    pt1 = (int(x * image_scale), int(y * image_scale))
+                    pt2 = (int((x + w) * image_scale), int((y + h) * image_scale))
+                    cv2.rectangle(img, pt1, pt2, (255, 0, 0), 3, 8, 0)
+
+        cv2.imshow("compressed_result", img)
+        cv2.waitKey(6)
+
     rospy.init_node('rosfacedetect')
     rospy.Subscriber(options.topic, sensor_msgs.msg.Image, detect_and_draw)
+    rospy.Subscriber(options.ctopic, sensor_msgs.msg.CompressedImage, compressed_detect_and_draw)
     rospy.spin()

--- a/opencv_tests/nodes/source.py
+++ b/opencv_tests/nodes/source.py
@@ -2,6 +2,7 @@
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2008, Willow Garage, Inc.
+# Copyright (c) 2016, Tal Regev.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -41,50 +42,54 @@ import cv2
 import sensor_msgs.msg
 from cv_bridge import CvBridge
 
-class source:
 
-  def __init__(self):
-    self.pub = rospy.Publisher("/opencv_tests/images", sensor_msgs.msg.Image)
+# Send black pic with a circle as regular and compressed ros msgs.
+class Source:
 
-  def spin(self):
-    time.sleep(1.0)
-    started = time.time()
-    counter = 0
-    cvim = numpy.zeros((480, 640, 1), numpy.uint8)
-    ball_xv = 10
-    ball_yv = 10
-    ball_x = 100
-    ball_y = 100
+    def __init__(self):
+        self.pub            = rospy.Publisher("/opencv_tests/images", sensor_msgs.msg.Image)
+        self.pub_compressed = rospy.Publisher("/opencv_tests/images/compressed", sensor_msgs.msg.CompressedImage)
 
-    cvb = CvBridge()
+    def spin(self):
+        time.sleep(1.0)
+        started = time.time()
+        counter = 0
+        cvim = numpy.zeros((480, 640, 1), numpy.uint8)
+        ball_xv = 10
+        ball_yv = 10
+        ball_x = 100
+        ball_y = 100
 
-    while not rospy.core.is_shutdown():
+        cvb = CvBridge()
 
-      cvim.fill(0)
-      cv2.circle(cvim, (ball_x, ball_y), 10, 255, -1)
+        while not rospy.core.is_shutdown():
 
-      ball_x += ball_xv
-      ball_y += ball_yv
-      if ball_x in [10, 630]:
-        ball_xv = -ball_xv
-      if ball_y in [10, 470]:
-        ball_yv = -ball_yv
+            cvim.fill(0)
+            cv2.circle(cvim, (ball_x, ball_y), 10, 255, -1)
 
-      self.pub.publish(cvb.cv2_to_imgmsg(cvim))
+            ball_x += ball_xv
+            ball_y += ball_yv
+            if ball_x in [10, 630]:
+                ball_xv = -ball_xv
+            if ball_y in [10, 470]:
+                ball_yv = -ball_yv
 
-      time.sleep(0.03)
+            self.pub.publish(cvb.cv2_to_imgmsg(cvim))
+            self.pub_compressed.publish(cvb.cv2_to_compressed_imgmsg(cvim))
+            time.sleep(0.03)
+
 
 def main(args):
-  s = source()
-  rospy.init_node('source')
-  try:
-    s.spin()
-    rospy.spin()
-    outcome = 'test completed'
-  except KeyboardInterrupt:
-    print "shutting down"
-    outcome = 'keyboard interrupt'
-  rospy.core.signal_shutdown(outcome)
+    s = Source()
+    rospy.init_node('Source')
+    try:
+        s.spin()
+        rospy.spin()
+        outcome = 'test completed'
+    except KeyboardInterrupt:
+        print "shutting down"
+        outcome = 'keyboard interrupt'
+    rospy.core.signal_shutdown(outcome)
 
 if __name__ == '__main__':
-  main(sys.argv)
+    main(sys.argv)


### PR DESCRIPTION
- Add cv2_to_comprssed_imgmsg: Convert from cv2 image to compressed image ros msg.
- Add comprssed_imgmsg_to_cv2:   Convert the compress message to a new image.
- Add compressed image tests.
- Add time to msgs (compressed and regular).

add enumerants test for compressed image.
merge the compressed tests with the regular ones.
better comment explanation. I will squash this commit.

Fix indentation
fix typo mistage: from .imgmsg_to_compressed_cv2 to .compressed_imgmsg_to_cv2.

remove cv2.CV_8UC1
remove rospy and time depndency.

change from IMREAD_COLOR to IMREAD_ANYCOLOR.
- make indentaion of 4.
- remove space trailer.
- remove space from empty lines.
- another set of for loops, it will make things easier to track. In that new set,  just have the number of channels in ([],1,3,4) (ignore two for jpg). from: https://github.com/ros-perception/vision_opencv/pull/132#discussion_r66721943
- keep the OpenCV error message. from: https://github.com/ros-perception/vision_opencv/pull/132#discussion_r66721013

add debug print for test.

add case for 4 channels in test.

remove 4 channels case from compressed test.

add debug print for test.

change typo of format.

fix typo in format. change from dip to dib.
change to IMREAD_ANYCOLOR as python code. (as it should).

rename TIFF to tiff

Sperate the tests one for regular images and one for compressed.

(cherry picked from commit 58471a392a03925e260afb56a98ddc48719d123a)

update comment
