### PR TITLE
remap with nan border if mat value is float or double

### DIFF
--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -285,7 +285,13 @@ void PinholeCameraModel::rectifyImage(const cv::Mat& raw, cv::Mat& rectified, in
       break;
     case CALIBRATED:
       initRectificationMaps();
-      cv::remap(raw, rectified, cache_->reduced_map1, cache_->reduced_map2, interpolation);
+      if (raw.depth() == CV_32F || raw.depth() == CV_64F)
+      {
+        cv::remap(raw, rectified, cache_->reduced_map1, cache_->reduced_map2, interpolation, cv::BORDER_CONSTANT, std::numeric_limits<float>::quiet_NaN());
+      }
+      else {
+        cv::remap(raw, rectified, cache_->reduced_map1, cache_->reduced_map2, interpolation);
+      }
       break;
     default:
       assert(cache_->distortion_state == UNKNOWN);


### PR DESCRIPTION
I think border value should be NaN if the elements of Image are expressed in 32FC.

without this patch, in the process of depth2pointcloud in openni2_launch(or something),  the [0, 0, 0] clouds appears like this.
![screenshot from 2016-07-23 18 02 02](https://cloud.githubusercontent.com/assets/7259700/17095585/3afd012e-5290-11e6-99fd-9d58ad85e0b6.png)

It is because of this line.
https://github.com/ros-perception/image_pipeline/blob/indigo/depth_image_proc/include/depth_image_proc/depth_traits.h#L57
only nan values are removed.
