### PR TITLE
cv_bridge: Add missing test_depend on numpy

### DIFF
--- a/cv_bridge/package.xml
+++ b/cv_bridge/package.xml
@@ -32,6 +32,7 @@
   <build_export_depend>sensor_msgs</build_export_depend>
 
   <test_depend>rostest</test_depend>
+  <test_depend>python-numpy</test_depend>
 
   <doc_depend>dvipng</doc_depend>
 </package>


### PR DESCRIPTION
The `cv_bridge` tests depend on `numpy`, but the `package.xml` does not currently declare this. This PR adds the missing `<test_depend>`.
