### PR TITLE
address gcc6 build error in cv_bridge and tune

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -19,8 +19,7 @@ catkin_package(
 
 catkin_python_setup()
 
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${Boost_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 if(NOT ANDROID)
 add_subdirectory(python)

--- a/cv_bridge/src/CMakeLists.txt
+++ b/cv_bridge/src/CMakeLists.txt
@@ -26,10 +26,7 @@ if(NOT PYTHON_NUMPY_INCLUDE_DIR)
     endif(PYTHON_NUMPY_PROCESS EQUAL 0)
  endif(NOT PYTHON_NUMPY_INCLUDE_DIR)
 
-include_directories(SYSTEM ${PYTHON_INCLUDE_PATH}
-                           ${Boost_INCLUDE_DIRS}
-                           ${PYTHON_NUMPY_INCLUDE_DIR} # cv_bridge module uses NumPy functions
-)
+include_directories(${PYTHON_INCLUDE_PATH} ${Boost_INCLUDE_DIRS} ${PYTHON_NUMPY_INCLUDE_DIR})
 
 if (PYTHON_VERSION_MAJOR VERSION_EQUAL 3)
   add_definitions(-DPYTHON3)


### PR DESCRIPTION
With gcc6, compiling fails with `stdlib.h: No such file or directory`, as including '-isystem /usr/include' breaks with gcc6, cf., https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.

This commit addresses this issue for cv_bridge in the same way it was done in the commit ead421b8 [1] for image_geometry. This issue was also addressed in various other ROS packages.
A list of related commits and pull requests is at https://github.com/ros/rosdistro/issues/12783.

[1] https://github.com/ros-perception/vision_opencv/commit/ead421b85eeb750cbf7988657015296ed6789bcf
