### PR TITLE
Import using __future__ for python 3 compatibility.

### DIFF
--- a/image_geometry/src/image_geometry/__init__.py
+++ b/image_geometry/src/image_geometry/__init__.py
@@ -1,1 +1,2 @@
-from cameramodels import PinholeCameraModel, StereoCameraModel
+from __future__ import absolute_import
+from .cameramodels import PinholeCameraModel, StereoCameraModel


### PR DESCRIPTION
Title says it all I suppose. My python3 interpreter failed to find cameramodels because it wasn't searching relative to __init__.py.