### PR TITLE
Silence warnings about un-used variables

### DIFF
--- a/cv_bridge/include/cv_bridge/cv_bridge.h
+++ b/cv_bridge/include/cv_bridge/cv_bridge.h
@@ -404,7 +404,7 @@ namespace message_operations {
 template<> struct Printer<cv_bridge::CvImage>
 {
   template<typename Stream>
-  static void stream(Stream& s, const std::string& indent, const cv_bridge::CvImage& m)
+  static void stream(Stream&, const std::string&, const cv_bridge::CvImage&)
   {
     /// @todo Replicate printing for sensor_msgs::Image
   }


### PR DESCRIPTION
When the header is included in a project specifying gcc flags `-Wall -Wextra` the following warnings appear:

```cpp
/opt/ros/kinetic/include/cv_bridge/cv_bridge.h: In instantiation of ‘static void ros::message_operations::Printer<cv_bridge::CvImage>::stream(Stream&, const string&, const cv_bridge::CvImage&) [with Stream = std::basic_ostream<char>; std::__cxx11::string = std::__cxx11::basic_string<char>]’:
/opt/ros/kinetic/include/cv_bridge/cv_bridge.h:421:61:   required from here
/opt/ros/kinetic/include/cv_bridge/cv_bridge.h:407:30: warning: unused parameter ‘s’ [-Wunused-parameter]
   static void stream(Stream& s, const std::string& indent, const cv_bridge::CvImage& m)
                              ^
/opt/ros/kinetic/include/cv_bridge/cv_bridge.h:407:52: warning: unused parameter ‘indent’ [-Wunused-parameter]
   static void stream(Stream& s, const std::string& indent, const cv_bridge::CvImage& m)
                                                    ^~~~~~
/opt/ros/kinetic/include/cv_bridge/cv_bridge.h:407:86: warning: unused parameter ‘m’ [-Wunused-parameter]
   static void stream(Stream& s, const std::string& indent, const cv_bridge::CvImage& m)
                                                                                      ^

```