### PR TITLE
Remove the last remnants of boost from image_geometry.

### DIFF
--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -12,6 +12,8 @@ catkin_package(CATKIN_DEPENDS sensor_msgs
 
 catkin_python_setup()
 
+add_compile_options(-std=c++11)
+
 include_directories(${catkin_INCLUDE_DIRS}
                            ${OpenCV_INCLUDE_DIRS}
 )

--- a/image_geometry/include/image_geometry/pinhole_camera_model.h
+++ b/image_geometry/include/image_geometry/pinhole_camera_model.h
@@ -22,7 +22,7 @@ public:
 class PinholeCameraModel
 {
 public:
-  
+
   PinholeCameraModel();
 
   PinholeCameraModel(const PinholeCameraModel& other);
@@ -270,7 +270,7 @@ protected:
 
   // Use PIMPL here so we can change internals in patch updates if needed
   struct Cache;
-  boost::shared_ptr<Cache> cache_; // Holds cached data for internal use
+  std::shared_ptr<Cache> cache_; // Holds cached data for internal use
 
   void initRectificationMaps() const;
 

--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -1,6 +1,7 @@
+#include <memory>
+
 #include "image_geometry/pinhole_camera_model.h"
 #include <sensor_msgs/distortion_models.h>
-#include <boost/make_shared.hpp>
 
 namespace image_geometry {
 
@@ -11,13 +12,13 @@ struct PinholeCameraModel::Cache
   DistortionState distortion_state;
 
   cv::Mat_<double> K_binned, P_binned; // Binning applied, but not cropping
-  
+
   mutable bool full_maps_dirty;
   mutable cv::Mat full_map1, full_map2;
 
   mutable bool reduced_maps_dirty;
   mutable cv::Mat reduced_map1, reduced_map2;
-  
+
   mutable bool rectified_roi_dirty;
   mutable cv::Rect rectified_roi;
 
@@ -56,7 +57,7 @@ bool update(const T& new_val, T& my_val)
   return true;
 }
 
-// For boost::array, std::vector
+// For std::vector
 template<typename MatT>
 bool updateMat(const MatT& new_mat, MatT& my_mat, cv::Mat_<double>& cv_mat, int rows, int cols)
 {
@@ -83,8 +84,8 @@ bool PinholeCameraModel::fromCameraInfo(const sensor_msgs::CameraInfo& msg)
 {
   // Create our repository of cached data (rectification maps, etc.)
   if (!cache_)
-    cache_ = boost::make_shared<Cache>();
-  
+    cache_ = std::make_shared<Cache>();
+
   // Binning = 0 is considered the same as binning = 1 (no binning).
   uint32_t binning_x = msg.binning_x ? msg.binning_x : 1;
   uint32_t binning_y = msg.binning_y ? msg.binning_y : 1;
@@ -98,7 +99,7 @@ bool PinholeCameraModel::fromCameraInfo(const sensor_msgs::CameraInfo& msg)
 
   // Update time stamp (and frame_id if that changes for some reason)
   cam_info_.header = msg.header;
-  
+
   // Update any parameters that have changed. The full rectification maps are
   // invalidated by any change in the calibration parameters OR binning.
   bool &full_dirty = cache_->full_maps_dirty;


### PR DESCRIPTION
All of its functionality can be had from std:: in C++11, so
use that instead.  This also requires us to add the -std=c++11
flag.

Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>