### PR TITLE
[cv_bridge] Convert 8UC image msg to mono8 image

### DIFF
--- a/cv_bridge/src/cv_bridge.cpp
+++ b/cv_bridge/src/cv_bridge.cpp
@@ -197,13 +197,20 @@ std::map<std::pair<Encoding, Encoding>, std::vector<int> > getConversionCodes() 
   return res;
 }
 
+const bool isMono(const std::string encoding)
+{
+  return encoding == enc::MONO8 || encoding == enc::MONO16 ||
+         encoding == "8UC" || encoding == enc::TYPE_8UC1 ||
+         encoding == "16UC" || encoding == enc::TYPE_16UC1;
+}
+
 const std::vector<int> getConversionCode(std::string src_encoding, std::string dst_encoding)
 {
   Encoding src_encod = getEncoding(src_encoding);
   Encoding dst_encod = getEncoding(dst_encoding);
-  bool is_src_color_format = enc::isColor(src_encoding) || enc::isMono(src_encoding) ||
+  bool is_src_color_format = enc::isColor(src_encoding) || isMono(src_encoding) ||
                              enc::isBayer(src_encoding) || (src_encoding == enc::YUV422);
-  bool is_dst_color_format = enc::isColor(dst_encoding) || enc::isMono(dst_encoding) ||
+  bool is_dst_color_format = enc::isColor(dst_encoding) || isMono(dst_encoding) ||
                              enc::isBayer(dst_encoding) || (dst_encoding == enc::YUV422);
   bool is_num_channels_the_same = (enc::numChannels(src_encoding) == enc::numChannels(dst_encoding));
 

--- a/cv_bridge/src/cv_bridge.cpp
+++ b/cv_bridge/src/cv_bridge.cpp
@@ -297,6 +297,27 @@ cv::Mat matFromImage(const sensor_msgs::Image& source)
   return mat_swap;
 }
 
+// Internal, used by toCvCopyImpl
+bool isSameEncoding(const std::string& encoding_a, const std::string& encoding_b)
+{
+  std::vector<std::string> mono8_encodings;
+  mono8_encodings.push_back("mono8");
+  mono8_encodings.push_back("8UC");
+  mono8_encodings.push_back("8UC1");
+  std::vector<std::string> mono16_encodings;
+  mono16_encodings.push_back("mono16");
+  mono16_encodings.push_back("16UC");
+  mono16_encodings.push_back("16UC1");
+  if (std::find(mono8_encodings.begin(), mono8_encodings.end(), encoding_a) != mono8_encodings.end() &&
+      std::find(mono8_encodings.begin(), mono8_encodings.end(), encoding_b) != mono8_encodings.end())
+    return true;
+  else if (std::find(mono16_encodings.begin(), mono16_encodings.end(), encoding_a) != mono16_encodings.end() &&
+           std::find(mono16_encodings.begin(), mono16_encodings.end(), encoding_b) != mono16_encodings.end())
+    return true;
+  else
+    return encoding_a == encoding_b;
+}
+
 // Internal, used by toCvCopy and cvtColor
 CvImagePtr toCvCopyImpl(const cv::Mat& source,
                         const std_msgs::Header& src_header,
@@ -308,9 +329,9 @@ CvImagePtr toCvCopyImpl(const cv::Mat& source,
   ptr->header = src_header;
   
   // Copy to new buffer if same encoding requested
-  if (dst_encoding.empty() || dst_encoding == src_encoding)
+  if (dst_encoding.empty() || isSameEncoding(src_encoding, dst_encoding))
   {
-    ptr->encoding = src_encoding;
+    ptr->encoding = dst_encoding;
     source.copyTo(ptr->image);
   }
   else


### PR DESCRIPTION
8UC is the same image encoding as mono8, and conversion between them should be possible.

Close https://github.com/ros-perception/vision_opencv/issues/175
Depends on https://github.com/ros/common_msgs/pull/107