### PR TITLE
Adding image rectification for equidistant model (fisheye lenses)

### DIFF
--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -128,7 +128,7 @@ bool PinholeCameraModel::fromCameraInfo(const sensor_msgs::CameraInfo& msg)
   // Figure out how to handle the distortion
   if (cam_info_.distortion_model == sensor_msgs::distortion_models::PLUMB_BOB ||
       cam_info_.distortion_model == sensor_msgs::distortion_models::RATIONAL_POLYNOMIAL ||
-      cam_info_.distortion_model == "equidistant") {
+      cam_info_.distortion_model == sensor_msgs::distortion_models::EQUIDISTANT) {
     // If any distortion coefficient is non-zero, then need to apply the distortion
     cache_->distortion_state = NONE;
     for (size_t i = 0; i < cam_info_.D.size(); ++i)

--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -127,7 +127,8 @@ bool PinholeCameraModel::fromCameraInfo(const sensor_msgs::CameraInfo& msg)
 
   // Figure out how to handle the distortion
   if (cam_info_.distortion_model == sensor_msgs::distortion_models::PLUMB_BOB ||
-      cam_info_.distortion_model == sensor_msgs::distortion_models::RATIONAL_POLYNOMIAL) {
+      cam_info_.distortion_model == sensor_msgs::distortion_models::RATIONAL_POLYNOMIAL ||
+      cam_info_.distortion_model == "equidistant") {
     // If any distortion coefficient is non-zero, then need to apply the distortion
     cache_->distortion_state = NONE;
     for (size_t i = 0; i < cam_info_.D.size(); ++i)
@@ -443,10 +444,15 @@ void PinholeCameraModel::initRectificationMaps() const
         P_binned(1,3) *= scale_y;
       }
     }
-    
-    // Note: m1type=CV_16SC2 to use fast fixed-point maps (see cv::remap)
-    cv::initUndistortRectifyMap(K_binned, D_, R_, P_binned, binned_resolution,
-                                CV_16SC2, cache_->full_map1, cache_->full_map2);
+
+    if (cameraInfo().distortion_model.compare(sensor_msgs::distortion_models::PLUMB_BOB) == 0) {
+      // Note: m1type=CV_16SC2 to use fast fixed-point maps (see cv::remap)
+      cv::initUndistortRectifyMap(K_binned, D_, R_, P_binned, binned_resolution,
+                                  CV_16SC2, cache_->full_map1, cache_->full_map2);
+    } else if (cameraInfo().distortion_model.compare("equidistant") == 0) {
+      cv::fisheye::initUndistortRectifyMap(K_binned, D_, R_, P_binned, binned_resolution,
+                                           CV_16SC2, cache_->full_map1, cache_->full_map2);
+    }
     cache_->full_maps_dirty = false;
   }
 


### PR DESCRIPTION
OpenCV now has support for fisheye models (named "equidistant" in other places), which can be integrated into image_geometry to undistort fisheye cameras using image_proc. 

Note that there is currently no distortion model for this defined in sensor_msgs, and an appropriate constant will need to be defined.