### PR TITLE
add version_gte for opencv3

### DIFF
--- a/cv_bridge/package.xml
+++ b/cv_bridge/package.xml
@@ -20,13 +20,13 @@
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>boost</build_depend>
-  <build_depend>opencv3</build_depend>
+  <build_depend version_gte="3.3.0">opencv3</build_depend>
   <build_depend>python</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
   <exec_depend>boost</exec_depend>
-  <exec_depend>opencv3</exec_depend>
+  <exec_depend version_gte="3.3.0">opencv3</exec_depend>
   <exec_depend>python</exec_depend>
   <exec_depend>rosconsole</exec_depend>
   <build_export_depend>sensor_msgs</build_export_depend>


### PR DESCRIPTION
@vrabaud If you'll update opencv3 version as discussed in https://discourse.ros.org/t/opencv-3-3/2674/4, I think we'd better to add 'version_gte' tag so that apt-get install ros-kinetic-cv-bridge also pulls openv3.3 from repository, to avoid API breaking issue between opencv2 and opencv3.