### PR TITLE
missing STL includes

### DIFF
--- a/image_geometry/include/image_geometry/pinhole_camera_model.h
+++ b/image_geometry/include/image_geometry/pinhole_camera_model.h
@@ -5,7 +5,9 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/calib3d/calib3d.hpp>
+#include <memory>
 #include <stdexcept>
+#include <string>
 
 namespace image_geometry {
 


### PR DESCRIPTION
Follow-up of #165, this should fix (at least partially) the regressions we've seen recently on kinetic (e.g. http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__depthimage_to_laserscan__ubuntu_xenial_amd64__binary/31)