### PR TITLE
Port image_geometry to ROS2

### DIFF
--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -3,8 +3,13 @@ project(image_geometry)
 
 find_package(ament_cmake_ros REQUIRED)
 
-if(NOT WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra)
 endif()
 
 find_package(OpenCV REQUIRED)

--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -40,4 +40,5 @@ endif()
 
 ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(OpenCV)
+ament_export_include_directories(include)
 ament_package()

--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra)
 endif()
 
-find_package(OpenCV REQUIRED)
+find_package(OpenCV REQUIRED COMPONENTS calib3d core highgui imgproc)
 find_package(sensor_msgs REQUIRED)
 
 include_directories(include)

--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(image_geometry)
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 
 if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
@@ -10,13 +10,12 @@ endif()
 find_package(OpenCV REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-include_directories(
-  include
-  ${OpenCV_INCLUDE_DIRS}
-)
+include_directories(include)
 
 # add a library
-add_library(${PROJECT_NAME} src/pinhole_camera_model.cpp src/stereo_camera_model.cpp)
+add_library(${PROJECT_NAME}
+  src/pinhole_camera_model.cpp src/stereo_camera_model.cpp
+)
 target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES})
 ament_target_dependencies(${PROJECT_NAME}
   "OpenCV"
@@ -27,11 +26,21 @@ install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION include/${PROJECT_NAME}
 )
 
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(${PROJECT_NAME} PRIVATE "IMAGE_GEOMETRY_BUILDING_DLL")
+
 install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION bin
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
 )
+
+# image_geometry_lib_dir is passed as APPEND_LIBRARY_DIRS for each ament_add_gtest call so
+# the project library that they link against is on the library path.
+# This is especially important on Windows.
+# This is overwritten each loop, but which one it points to doesn't really matter.
+set(image_geometry_lib_dir "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
 
 # add tests
 if(BUILD_TESTING)

--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -9,7 +9,6 @@ endif()
 
 find_package(OpenCV REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(Boost REQUIRED)
 
 include_directories(
   include

--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -1,36 +1,44 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(image_geometry)
 
-find_package(catkin REQUIRED sensor_msgs)
+find_package(ament_cmake REQUIRED)
+
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
+endif()
+
 find_package(OpenCV REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(Boost REQUIRED)
 
-catkin_package(CATKIN_DEPENDS sensor_msgs
-               DEPENDS OpenCV
-               INCLUDE_DIRS include
-               LIBRARIES ${PROJECT_NAME}
+include_directories(
+  include
+  ${OpenCV_INCLUDE_DIRS}
 )
-
-catkin_python_setup()
-
-include_directories(include)
-include_directories(${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 
 # add a library
 add_library(${PROJECT_NAME} src/pinhole_camera_model.cpp src/stereo_camera_model.cpp)
 target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES})
-add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+ament_target_dependencies(${PROJECT_NAME}
+  "OpenCV"
+  "sensor_msgs"
+)
 
 install(DIRECTORY include/${PROJECT_NAME}/
-        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/
+        DESTINATION include/${PROJECT_NAME}
 )
 
 install(TARGETS ${PROJECT_NAME}
-        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION bin
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
 )
 
 # add tests
-if(CATKIN_ENABLE_TESTING)
+if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
+
+ament_export_libraries(${PROJECT_NAME})
+ament_export_dependencies(OpenCV)
+ament_package()

--- a/image_geometry/include/image_geometry/pinhole_camera_model.h
+++ b/image_geometry/include/image_geometry/pinhole_camera_model.h
@@ -1,6 +1,8 @@
 #ifndef IMAGE_GEOMETRY_PINHOLE_CAMERA_MODEL_H
 #define IMAGE_GEOMETRY_PINHOLE_CAMERA_MODEL_H
 
+#include "image_geometry/visibility_control.hpp"
+
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
@@ -23,31 +25,37 @@ public:
 class PinholeCameraModel
 {
 public:
-
+  IMAGE_GEOMETRY_PUBLIC
   PinholeCameraModel();
 
+  IMAGE_GEOMETRY_PUBLIC
   PinholeCameraModel(const PinholeCameraModel& other);
 
+  IMAGE_GEOMETRY_PUBLIC
   PinholeCameraModel& operator=(const PinholeCameraModel& other);
 
   /**
    * \brief Set the camera parameters from the sensor_msgs/CameraInfo message.
    */
+  IMAGE_GEOMETRY_PUBLIC
   bool fromCameraInfo(const sensor_msgs::msg::CameraInfo& msg);
 
   /**
    * \brief Set the camera parameters from the sensor_msgs/CameraInfo message.
    */
+  IMAGE_GEOMETRY_PUBLIC
   bool fromCameraInfo(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& msg);
 
   /**
    * \brief Get the name of the camera coordinate frame in tf.
    */
+  IMAGE_GEOMETRY_PUBLIC
   std::string tfFrame() const;
 
   /**
    * \brief Get the time stamp associated with this camera model.
    */
+  IMAGE_GEOMETRY_PUBLIC
   builtin_interfaces::msg::Time stamp() const;
 
   /**
@@ -56,6 +64,7 @@ public:
    * The maximum resolution at which the camera can be used with the current
    * calibration; normally this is the same as the imager resolution.
    */
+  IMAGE_GEOMETRY_PUBLIC
   cv::Size fullResolution() const;
 
   /**
@@ -65,24 +74,31 @@ public:
    * reduced by binning/ROI and affected by distortion. If binning and ROI are
    * not in use, this is the same as fullResolution().
    */
+  IMAGE_GEOMETRY_PUBLIC
   cv::Size reducedResolution() const;
 
+  IMAGE_GEOMETRY_PUBLIC
   cv::Point2d toFullResolution(const cv::Point2d& uv_reduced) const;
 
+  IMAGE_GEOMETRY_PUBLIC
   cv::Rect toFullResolution(const cv::Rect& roi_reduced) const;
 
+  IMAGE_GEOMETRY_PUBLIC
   cv::Point2d toReducedResolution(const cv::Point2d& uv_full) const;
 
+  IMAGE_GEOMETRY_PUBLIC
   cv::Rect toReducedResolution(const cv::Rect& roi_full) const;
 
   /**
    * \brief The current raw ROI, as used for capture by the camera driver.
    */
+  IMAGE_GEOMETRY_PUBLIC
   cv::Rect rawRoi() const;
 
   /**
    * \brief The current rectified ROI, which best fits the raw ROI.
    */
+  IMAGE_GEOMETRY_PUBLIC
   cv::Rect rectifiedRoi() const;
 
   /**
@@ -93,6 +109,7 @@ public:
    * \param xyz 3d point in the camera coordinate frame
    * \return (u,v) in rectified pixel coordinates
    */
+  IMAGE_GEOMETRY_PUBLIC
   cv::Point2d project3dToPixel(const cv::Point3d& xyz) const;
 
   /**
@@ -106,113 +123,135 @@ public:
    * \param uv_rect Rectified pixel coordinates
    * \return 3d ray passing through (u,v)
    */
+  IMAGE_GEOMETRY_PUBLIC
   cv::Point3d projectPixelTo3dRay(const cv::Point2d& uv_rect) const;
 
   /**
    * \brief Rectify a raw camera image.
    */
+  IMAGE_GEOMETRY_PUBLIC
   void rectifyImage(const cv::Mat& raw, cv::Mat& rectified,
                     int interpolation = cv::INTER_LINEAR) const;
 
   /**
    * \brief Apply camera distortion to a rectified image.
    */
+  IMAGE_GEOMETRY_PUBLIC
   void unrectifyImage(const cv::Mat& rectified, cv::Mat& raw,
                       int interpolation = cv::INTER_LINEAR) const;
 
   /**
    * \brief Compute the rectified image coordinates of a pixel in the raw image.
    */
+  IMAGE_GEOMETRY_PUBLIC
   cv::Point2d rectifyPoint(const cv::Point2d& uv_raw) const;
 
   /**
    * \brief Compute the raw image coordinates of a pixel in the rectified image.
    */
+  IMAGE_GEOMETRY_PUBLIC
   cv::Point2d unrectifyPoint(const cv::Point2d& uv_rect) const;
 
   /**
    * \brief Compute the rectified ROI best fitting a raw ROI.
    */
+  IMAGE_GEOMETRY_PUBLIC
   cv::Rect rectifyRoi(const cv::Rect& roi_raw) const;
 
   /**
    * \brief Compute the raw ROI best fitting a rectified ROI.
    */
+  IMAGE_GEOMETRY_PUBLIC
   cv::Rect unrectifyRoi(const cv::Rect& roi_rect) const;
 
   /**
    * \brief Returns the camera info message held internally
    */
+  IMAGE_GEOMETRY_PUBLIC
   const sensor_msgs::msg::CameraInfo& cameraInfo() const;
 
   /**
    * \brief Returns the original camera matrix.
    */
+  IMAGE_GEOMETRY_PUBLIC
   const cv::Matx33d& intrinsicMatrix() const;
 
   /**
    * \brief Returns the distortion coefficients.
    */
+  IMAGE_GEOMETRY_PUBLIC
   const cv::Mat_<double>& distortionCoeffs() const;
 
   /**
    * \brief Returns the rotation matrix.
    */
+  IMAGE_GEOMETRY_PUBLIC
   const cv::Matx33d& rotationMatrix() const;
 
   /**
    * \brief Returns the projection matrix.
    */
+  IMAGE_GEOMETRY_PUBLIC
   const cv::Matx34d& projectionMatrix() const;
 
   /**
    * \brief Returns the original camera matrix for full resolution.
    */
+  IMAGE_GEOMETRY_PUBLIC
   const cv::Matx33d& fullIntrinsicMatrix() const;
 
   /**
    * \brief Returns the projection matrix for full resolution.
    */
+  IMAGE_GEOMETRY_PUBLIC
   const cv::Matx34d& fullProjectionMatrix() const;
 
   /**
    * \brief Returns the focal length (pixels) in x direction of the rectified image.
    */
+  IMAGE_GEOMETRY_PUBLIC
   double fx() const;
 
   /**
    * \brief Returns the focal length (pixels) in y direction of the rectified image.
    */
+  IMAGE_GEOMETRY_PUBLIC
   double fy() const;
 
   /**
    * \brief Returns the x coordinate of the optical center.
    */
+  IMAGE_GEOMETRY_PUBLIC
   double cx() const;
 
   /**
    * \brief Returns the y coordinate of the optical center.
    */
+  IMAGE_GEOMETRY_PUBLIC
   double cy() const;
 
   /**
    * \brief Returns the x-translation term of the projection matrix.
    */
+  IMAGE_GEOMETRY_PUBLIC
   double Tx() const;
 
   /**
    * \brief Returns the y-translation term of the projection matrix.
    */
+  IMAGE_GEOMETRY_PUBLIC
   double Ty() const;
 
   /**
    * \brief Returns the number of columns in each bin.
    */
+  IMAGE_GEOMETRY_PUBLIC
   uint32_t binningX() const;
 
   /**
    * \brief Returns the number of rows in each bin.
    */
+  IMAGE_GEOMETRY_PUBLIC
   uint32_t binningY() const;
   
   /**
@@ -223,6 +262,7 @@ public:
    * \param deltaX Delta X, in Cartesian space
    * \param Z      Z (depth), in Cartesian space
    */
+  IMAGE_GEOMETRY_PUBLIC
   double getDeltaU(double deltaX, double Z) const;
 
   /**
@@ -233,6 +273,7 @@ public:
    * \param deltaY Delta Y, in Cartesian space
    * \param Z      Z (depth), in Cartesian space
    */
+  IMAGE_GEOMETRY_PUBLIC
   double getDeltaV(double deltaY, double Z) const;
 
   /**
@@ -243,6 +284,7 @@ public:
    * \param deltaU Delta u, in pixels
    * \param Z      Z (depth), in Cartesian space
    */
+  IMAGE_GEOMETRY_PUBLIC
   double getDeltaX(double deltaU, double Z) const;
 
   /**
@@ -253,11 +295,13 @@ public:
    * \param deltaV Delta v, in pixels
    * \param Z      Z (depth), in Cartesian space
    */
+  IMAGE_GEOMETRY_PUBLIC
   double getDeltaY(double deltaV, double Z) const;
 
   /**
    * \brief Returns true if the camera has been initialized
    */
+  IMAGE_GEOMETRY_PUBLIC
   bool initialized() const { return (bool)cache_; }
 
 protected:
@@ -277,6 +321,7 @@ protected:
   std::shared_ptr<Cache> cache_; // Holds cached data for internal use
 #endif
 
+  IMAGE_GEOMETRY_PUBLIC
   void initRectificationMaps() const;
 
   friend class StereoCameraModel;
@@ -284,54 +329,75 @@ protected:
 
 
 /* Trivial inline functions */
+IMAGE_GEOMETRY_PUBLIC
 inline std::string PinholeCameraModel::tfFrame() const
 {
   assert( initialized() );
   return cam_info_.header.frame_id;
 }
 
+IMAGE_GEOMETRY_PUBLIC
 inline builtin_interfaces::msg::Time PinholeCameraModel::stamp() const
 {
   assert( initialized() );
   return cam_info_.header.stamp;
 }
 
+IMAGE_GEOMETRY_PUBLIC
 inline const sensor_msgs::msg::CameraInfo& PinholeCameraModel::cameraInfo() const  { return cam_info_; }
+IMAGE_GEOMETRY_PUBLIC
 inline const cv::Matx33d& PinholeCameraModel::intrinsicMatrix() const  { return K_; }
+IMAGE_GEOMETRY_PUBLIC
 inline const cv::Mat_<double>& PinholeCameraModel::distortionCoeffs() const { return D_; }
+IMAGE_GEOMETRY_PUBLIC
 inline const cv::Matx33d& PinholeCameraModel::rotationMatrix() const   { return R_; }
+IMAGE_GEOMETRY_PUBLIC
 inline const cv::Matx34d& PinholeCameraModel::projectionMatrix() const { return P_; }
+IMAGE_GEOMETRY_PUBLIC
 inline const cv::Matx33d& PinholeCameraModel::fullIntrinsicMatrix() const  { return K_full_; }
+IMAGE_GEOMETRY_PUBLIC
 inline const cv::Matx34d& PinholeCameraModel::fullProjectionMatrix() const { return P_full_; }
 
+IMAGE_GEOMETRY_PUBLIC
 inline double PinholeCameraModel::fx() const { return P_(0,0); }
+IMAGE_GEOMETRY_PUBLIC
 inline double PinholeCameraModel::fy() const { return P_(1,1); }
+IMAGE_GEOMETRY_PUBLIC
 inline double PinholeCameraModel::cx() const { return P_(0,2); }
+IMAGE_GEOMETRY_PUBLIC
 inline double PinholeCameraModel::cy() const { return P_(1,2); }
+IMAGE_GEOMETRY_PUBLIC
 inline double PinholeCameraModel::Tx() const { return P_(0,3); }
+IMAGE_GEOMETRY_PUBLIC
 inline double PinholeCameraModel::Ty() const { return P_(1,3); }
 
+IMAGE_GEOMETRY_PUBLIC
 inline uint32_t PinholeCameraModel::binningX() const { return cam_info_.binning_x; }
+IMAGE_GEOMETRY_PUBLIC
 inline uint32_t PinholeCameraModel::binningY() const { return cam_info_.binning_y; }
 
+IMAGE_GEOMETRY_PUBLIC
 inline double PinholeCameraModel::getDeltaU(double deltaX, double Z) const
 {
   assert( initialized() );
   return fx() * deltaX / Z;
 }
 
+IMAGE_GEOMETRY_PUBLIC
 inline double PinholeCameraModel::getDeltaV(double deltaY, double Z) const
 {
   assert( initialized() );
   return fy() * deltaY / Z;
 }
 
+IMAGE_GEOMETRY_PUBLIC
 inline double PinholeCameraModel::getDeltaX(double deltaU, double Z) const
 {
   assert( initialized() );
   return Z * deltaU / fx();
 }
 
+IMAGE_GEOMETRY_PUBLIC
 inline double PinholeCameraModel::getDeltaY(double deltaV, double Z) const
 {
   assert( initialized() );

--- a/image_geometry/include/image_geometry/pinhole_camera_model.h
+++ b/image_geometry/include/image_geometry/pinhole_camera_model.h
@@ -315,11 +315,7 @@ protected:
 
   // Use PIMPL here so we can change internals in patch updates if needed
   struct Cache;
-#ifdef BOOST_SHARED_PTR_HPP_INCLUDED
-  boost::shared_ptr<Cache> cache_; // Holds cached data for internal use
-#else
   std::shared_ptr<Cache> cache_; // Holds cached data for internal use
-#endif
 
   IMAGE_GEOMETRY_PUBLIC
   void initRectificationMaps() const;

--- a/image_geometry/include/image_geometry/pinhole_camera_model.h
+++ b/image_geometry/include/image_geometry/pinhole_camera_model.h
@@ -1,7 +1,7 @@
 #ifndef IMAGE_GEOMETRY_PINHOLE_CAMERA_MODEL_H
 #define IMAGE_GEOMETRY_PINHOLE_CAMERA_MODEL_H
 
-#include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/msg/camera_info.hpp>
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/calib3d/calib3d.hpp>
@@ -33,12 +33,12 @@ public:
   /**
    * \brief Set the camera parameters from the sensor_msgs/CameraInfo message.
    */
-  bool fromCameraInfo(const sensor_msgs::CameraInfo& msg);
+  bool fromCameraInfo(const sensor_msgs::msg::CameraInfo& msg);
 
   /**
    * \brief Set the camera parameters from the sensor_msgs/CameraInfo message.
    */
-  bool fromCameraInfo(const sensor_msgs::CameraInfoConstPtr& msg);
+  bool fromCameraInfo(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& msg);
 
   /**
    * \brief Get the name of the camera coordinate frame in tf.
@@ -48,7 +48,7 @@ public:
   /**
    * \brief Get the time stamp associated with this camera model.
    */
-  ros::Time stamp() const;
+  builtin_interfaces::msg::Time stamp() const;
 
   /**
    * \brief The resolution at which the camera was calibrated.
@@ -143,7 +143,7 @@ public:
   /**
    * \brief Returns the camera info message held internally
    */
-  const sensor_msgs::CameraInfo& cameraInfo() const;
+  const sensor_msgs::msg::CameraInfo& cameraInfo() const;
 
   /**
    * \brief Returns the original camera matrix.
@@ -261,7 +261,7 @@ public:
   bool initialized() const { return (bool)cache_; }
 
 protected:
-  sensor_msgs::CameraInfo cam_info_;
+  sensor_msgs::msg::CameraInfo cam_info_;
   cv::Mat_<double> D_;           // Unaffected by binning, ROI
   cv::Matx33d R_;           // Unaffected by binning, ROI
   cv::Matx33d K_;           // Describe current image (includes binning, ROI)
@@ -290,13 +290,13 @@ inline std::string PinholeCameraModel::tfFrame() const
   return cam_info_.header.frame_id;
 }
 
-inline ros::Time PinholeCameraModel::stamp() const
+inline builtin_interfaces::msg::Time PinholeCameraModel::stamp() const
 {
   assert( initialized() );
   return cam_info_.header.stamp;
 }
 
-inline const sensor_msgs::CameraInfo& PinholeCameraModel::cameraInfo() const  { return cam_info_; }
+inline const sensor_msgs::msg::CameraInfo& PinholeCameraModel::cameraInfo() const  { return cam_info_; }
 inline const cv::Matx33d& PinholeCameraModel::intrinsicMatrix() const  { return K_; }
 inline const cv::Mat_<double>& PinholeCameraModel::distortionCoeffs() const { return D_; }
 inline const cv::Matx33d& PinholeCameraModel::rotationMatrix() const   { return R_; }

--- a/image_geometry/include/image_geometry/stereo_camera_model.h
+++ b/image_geometry/include/image_geometry/stereo_camera_model.h
@@ -2,6 +2,7 @@
 #define IMAGE_GEOMETRY_STEREO_CAMERA_MODEL_H
 
 #include "image_geometry/pinhole_camera_model.h"
+#include "image_geometry/visibility_control.hpp"
 
 namespace image_geometry {
 
@@ -12,32 +13,39 @@ namespace image_geometry {
 class StereoCameraModel
 {
 public:
+  IMAGE_GEOMETRY_PUBLIC
   StereoCameraModel();
 
+  IMAGE_GEOMETRY_PUBLIC
   StereoCameraModel(const StereoCameraModel& other);
 
+  IMAGE_GEOMETRY_PUBLIC
   StereoCameraModel& operator=(const StereoCameraModel& other);
 
   /**
    * \brief Set the camera parameters from the sensor_msgs/CameraInfo messages.
    */
+  IMAGE_GEOMETRY_PUBLIC
   bool fromCameraInfo(const sensor_msgs::msg::CameraInfo& left,
                       const sensor_msgs::msg::CameraInfo& right);
 
   /**
    * \brief Set the camera parameters from the sensor_msgs/CameraInfo messages.
    */
+  IMAGE_GEOMETRY_PUBLIC
   bool fromCameraInfo(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& left,
                       const sensor_msgs::msg::CameraInfo::ConstSharedPtr& right);
 
   /**
    * \brief Get the left monocular camera model.
    */
+  IMAGE_GEOMETRY_PUBLIC
   const PinholeCameraModel& left() const;
 
   /**
    * \brief Get the right monocular camera model.
    */
+  IMAGE_GEOMETRY_PUBLIC
   const PinholeCameraModel& right() const;
 
   /**
@@ -46,11 +54,13 @@ public:
    * For stereo cameras, both the left and right CameraInfo should be in the left
    * optical frame.
    */
+  IMAGE_GEOMETRY_PUBLIC
   std::string tfFrame() const;
 
   /**
    * \brief Project a rectified pixel with disparity to a 3d point.
    */
+  IMAGE_GEOMETRY_PUBLIC
   void projectDisparityTo3d(const cv::Point2d& left_uv_rect, float disparity, cv::Point3d& xyz) const;
 
   /**
@@ -59,6 +69,7 @@ public:
    * If handleMissingValues = true, all points with minimal disparity (outliers) have
    * Z set to MISSING_Z (currently 10000.0).
    */
+  IMAGE_GEOMETRY_PUBLIC
   void projectDisparityImageTo3d(const cv::Mat& disparity, cv::Mat& point_cloud,
                                  bool handleMissingValues = false) const;
   static const double MISSING_Z;
@@ -66,11 +77,13 @@ public:
   /**
    * \brief Returns the disparity reprojection matrix.
    */
+  IMAGE_GEOMETRY_PUBLIC
   const cv::Matx44d& reprojectionMatrix() const;
 
   /**
    * \brief Returns the horizontal baseline in world coordinates.
    */
+  IMAGE_GEOMETRY_PUBLIC
   double baseline() const;
 
   /**
@@ -78,6 +91,7 @@ public:
    *
    * This is the inverse of getDisparity().
    */
+  IMAGE_GEOMETRY_PUBLIC
   double getZ(double disparity) const;
 
   /**
@@ -85,40 +99,50 @@ public:
    *
    * This is the inverse of getZ().
    */
+  IMAGE_GEOMETRY_PUBLIC
   double getDisparity(double Z) const;
 
   /**
    * \brief Returns true if the camera has been initialized
    */
+  IMAGE_GEOMETRY_PUBLIC
   bool initialized() const { return left_.initialized() && right_.initialized(); }
 protected:
   PinholeCameraModel left_, right_;
   cv::Matx44d Q_;
 
+  IMAGE_GEOMETRY_PUBLIC
   void updateQ();
 };
 
 
 /* Trivial inline functions */
+IMAGE_GEOMETRY_PUBLIC
 inline const PinholeCameraModel& StereoCameraModel::left() const  { return left_; }
+IMAGE_GEOMETRY_PUBLIC
 inline const PinholeCameraModel& StereoCameraModel::right() const { return right_; }
 
+IMAGE_GEOMETRY_PUBLIC
 inline std::string StereoCameraModel::tfFrame() const { return left_.tfFrame(); }
 
+IMAGE_GEOMETRY_PUBLIC
 inline const cv::Matx44d& StereoCameraModel::reprojectionMatrix() const { return Q_; }
 
+IMAGE_GEOMETRY_PUBLIC
 inline double StereoCameraModel::baseline() const
 {
   /// @todo Currently assuming horizontal baseline
   return -right_.Tx() / right_.fx();
 }
 
+IMAGE_GEOMETRY_PUBLIC
 inline double StereoCameraModel::getZ(double disparity) const
 {
   assert( initialized() );
   return -right_.Tx() / (disparity - (left().cx() - right().cx()));
 }
 
+IMAGE_GEOMETRY_PUBLIC
 inline double StereoCameraModel::getDisparity(double Z) const
 {
   assert( initialized() );

--- a/image_geometry/include/image_geometry/stereo_camera_model.h
+++ b/image_geometry/include/image_geometry/stereo_camera_model.h
@@ -21,14 +21,14 @@ public:
   /**
    * \brief Set the camera parameters from the sensor_msgs/CameraInfo messages.
    */
-  bool fromCameraInfo(const sensor_msgs::CameraInfo& left,
-                      const sensor_msgs::CameraInfo& right);
+  bool fromCameraInfo(const sensor_msgs::msg::CameraInfo& left,
+                      const sensor_msgs::msg::CameraInfo& right);
 
   /**
    * \brief Set the camera parameters from the sensor_msgs/CameraInfo messages.
    */
-  bool fromCameraInfo(const sensor_msgs::CameraInfoConstPtr& left,
-                      const sensor_msgs::CameraInfoConstPtr& right);
+  bool fromCameraInfo(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& left,
+                      const sensor_msgs::msg::CameraInfo::ConstSharedPtr& right);
 
   /**
    * \brief Get the left monocular camera model.

--- a/image_geometry/include/image_geometry/visibility_control.hpp
+++ b/image_geometry/include/image_geometry/visibility_control.hpp
@@ -1,0 +1,58 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IMAGE_GEOMETRY__VISIBILITY_CONTROL_H_
+#define IMAGE_GEOMETRY__VISIBILITY_CONTROL_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define IMAGE_GEOMETRY_EXPORT __attribute__ ((dllexport))
+    #define IMAGE_GEOMETRY_IMPORT __attribute__ ((dllimport))
+  #else
+    #define IMAGE_GEOMETRY_EXPORT __declspec(dllexport)
+    #define IMAGE_GEOMETRY_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef IMAGE_GEOMETRY_BUILDING_DLL
+    #define IMAGE_GEOMETRY_PUBLIC IMAGE_GEOMETRY_EXPORT
+  #else
+    #define IMAGE_GEOMETRY_PUBLIC IMAGE_GEOMETRY_IMPORT
+  #endif
+  #define IMAGE_GEOMETRY_PUBLIC_TYPE IMAGE_GEOMETRY_PUBLIC
+  #define IMAGE_GEOMETRY_LOCAL
+#else
+  #define IMAGE_GEOMETRY_EXPORT __attribute__ ((visibility("default")))
+  #define IMAGE_GEOMETRY_IMPORT
+  #if __GNUC__ >= 4
+    #define IMAGE_GEOMETRY_PUBLIC __attribute__ ((visibility("default")))
+    #define IMAGE_GEOMETRY_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define IMAGE_GEOMETRY_PUBLIC
+    #define IMAGE_GEOMETRY_LOCAL
+  #endif
+  #define IMAGE_GEOMETRY_PUBLIC_TYPE
+#endif
+
+#if __cplusplus
+}
+#endif
+
+#endif  // IMAGE_GEOMETRY__VISIBILITY_CONTROL_H_

--- a/image_geometry/package.xml
+++ b/image_geometry/package.xml
@@ -22,8 +22,8 @@
   <depend>libopencv-dev</depend>
   <depend>sensor_msgs</depend>
 
-  <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
 
   <doc_depend>dvipng</doc_depend>
   <doc_depend>texlive-latex-extra</doc_depend>

--- a/image_geometry/package.xml
+++ b/image_geometry/package.xml
@@ -19,7 +19,7 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <depend>opencv3</depend>
+  <depend>libopencv-dev</depend>
   <depend>sensor_msgs</depend>
 
   <test_depend>ament_cmake_nose</test_depend>

--- a/image_geometry/package.xml
+++ b/image_geometry/package.xml
@@ -13,17 +13,21 @@
   <url>http://www.ros.org/wiki/image_geometry</url>
 
   <export>
+    <build_type>ament_cmake</build_type>
     <rosdoc config="rosdoc.yaml" />
   </export>
 
-  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>opencv3</build_depend>
-  <build_depend>sensor_msgs</build_depend>
+  <depend>opencv3</depend>
+  <depend>sensor_msgs</depend>
 
-  <exec_depend>opencv3</exec_depend>
-  <build_export_depend>sensor_msgs</build_export_depend>
+  <build_depend>boost</build_depend>
+
+  <test_depend>ament_cmake_nose</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <doc_depend>dvipng</doc_depend>
   <doc_depend>texlive-latex-extra</doc_depend>
+
 </package>

--- a/image_geometry/package.xml
+++ b/image_geometry/package.xml
@@ -22,8 +22,6 @@
   <depend>opencv3</depend>
   <depend>sensor_msgs</depend>
 
-  <build_depend>boost</build_depend>
-
   <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/image_geometry/package.xml
+++ b/image_geometry/package.xml
@@ -17,7 +17,7 @@
     <rosdoc config="rosdoc.yaml" />
   </export>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>opencv3</depend>
   <depend>sensor_msgs</depend>

--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -383,18 +383,9 @@ cv::Point2d PinholeCameraModel::unrectifyPoint(const cv::Point2d& uv_rect) const
   cv::Mat r_vec, t_vec = cv::Mat_<double>::zeros(3, 1);
   cv::Rodrigues(R_.t(), r_vec);
   std::vector<cv::Point2d> image_point;
+  cv::projectPoints(std::vector<cv::Point3d>(1, ray), r_vec, t_vec, K_, D_, image_point);
 
-  // passing std::vector<..> to / from cv::projectPoints
-  // seems to not work on Windows in Debug mode with VS 2015
-  cv::Mat mat_in(1, 3, CV_64F);
-  mat_in.at<double>(0, 0) = ray.x;
-  mat_in.at<double>(0, 1) = ray.y;
-  mat_in.at<double>(0, 2) = ray.z;
-  cv::Mat mat_out(1, 1, CV_64F);
-
-  cv::projectPoints(mat_in, r_vec, t_vec, K_, D_, mat_out);
-
-  return cv::Point2d(mat_out.at<double>(0, 0), mat_out.at<double>(0, 1));
+  return image_point[0];
 }
 
 cv::Rect PinholeCameraModel::rectifyRoi(const cv::Rect& roi_raw) const

--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -1,8 +1,5 @@
 #include "image_geometry/pinhole_camera_model.h"
 #include <sensor_msgs/distortion_models.hpp>
-#ifdef BOOST_SHARED_PTR_HPP_INCLUDED
-#include <boost/make_shared.hpp>
-#endif
 
 namespace image_geometry {
 
@@ -102,11 +99,7 @@ bool PinholeCameraModel::fromCameraInfo(const sensor_msgs::msg::CameraInfo& msg)
 {
   // Create our repository of cached data (rectification maps, etc.)
   if (!cache_)
-#ifdef BOOST_SHARED_PTR_HPP_INCLUDED
-    cache_ = boost::make_shared<Cache>();
-#else
     cache_ = std::make_shared<Cache>();
-#endif
 
   // Binning = 0 is considered the same as binning = 1 (no binning).
   uint32_t binning_x = msg.binning_x ? msg.binning_x : 1;

--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -383,9 +383,18 @@ cv::Point2d PinholeCameraModel::unrectifyPoint(const cv::Point2d& uv_rect) const
   cv::Mat r_vec, t_vec = cv::Mat_<double>::zeros(3, 1);
   cv::Rodrigues(R_.t(), r_vec);
   std::vector<cv::Point2d> image_point;
-  cv::projectPoints(std::vector<cv::Point3d>(1, ray), r_vec, t_vec, K_, D_, image_point);
 
-  return image_point[0];
+  // passing std::vector<..> to / from cv::projectPoints
+  // seems to not work on Windows in Debug mode with VS 2015
+  cv::Mat mat_in(1, 3, CV_64F);
+  mat_in.at<double>(0, 0) = ray.x;
+  mat_in.at<double>(0, 1) = ray.y;
+  mat_in.at<double>(0, 2) = ray.z;
+  cv::Mat mat_out(1, 1, CV_64F);
+
+  cv::projectPoints(mat_in, r_vec, t_vec, K_, D_, mat_out);
+
+  return cv::Point2d(mat_out.at<double>(0, 0), mat_out.at<double>(0, 1));
 }
 
 cv::Rect PinholeCameraModel::rectifyRoi(const cv::Rect& roi_raw) const

--- a/image_geometry/src/stereo_camera_model.cpp
+++ b/image_geometry/src/stereo_camera_model.cpp
@@ -24,8 +24,8 @@ StereoCameraModel& StereoCameraModel::operator=(const StereoCameraModel& other)
   return *this;
 }
 
-bool StereoCameraModel::fromCameraInfo(const sensor_msgs::CameraInfo& left,
-                                       const sensor_msgs::CameraInfo& right)
+bool StereoCameraModel::fromCameraInfo(const sensor_msgs::msg::CameraInfo& left,
+                                       const sensor_msgs::msg::CameraInfo& right)
 {
   bool changed_left  = left_.fromCameraInfo(left);
   bool changed_right = right_.fromCameraInfo(right);
@@ -44,8 +44,8 @@ bool StereoCameraModel::fromCameraInfo(const sensor_msgs::CameraInfo& left,
   return changed;
 }
 
-bool StereoCameraModel::fromCameraInfo(const sensor_msgs::CameraInfoConstPtr& left,
-                                       const sensor_msgs::CameraInfoConstPtr& right)
+bool StereoCameraModel::fromCameraInfo(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& left,
+                                       const sensor_msgs::msg::CameraInfo::ConstSharedPtr& right)
 {
   return fromCameraInfo(*left, *right);
 }

--- a/image_geometry/test/CMakeLists.txt
+++ b/image_geometry/test/CMakeLists.txt
@@ -3,5 +3,5 @@ find_package(ament_cmake_gtest REQUIRED)
 
 ament_add_nose_test(directed.py .)
 
-ament_add_gtest(${PROJECT_NAME}-utest utest.cpp)
+ament_add_gtest(${PROJECT_NAME}-utest utest.cpp APPEND_LIBRARY_DIRS "${image_geometry_lib_dir}")
 target_link_libraries(${PROJECT_NAME}-utest ${PROJECT_NAME} ${OpenCV_LIBS})

--- a/image_geometry/test/CMakeLists.txt
+++ b/image_geometry/test/CMakeLists.txt
@@ -1,7 +1,7 @@
-find_package(ament_cmake_nose REQUIRED)
 find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_cmake_pytest REQUIRED)
 
-ament_add_nose_test(directed.py .)
+ament_add_pytest_test(directed.py .)
 
 ament_add_gtest(${PROJECT_NAME}-utest utest.cpp APPEND_LIBRARY_DIRS "${image_geometry_lib_dir}")
 target_link_libraries(${PROJECT_NAME}-utest ${PROJECT_NAME} ${OpenCV_LIBS})

--- a/image_geometry/test/CMakeLists.txt
+++ b/image_geometry/test/CMakeLists.txt
@@ -1,4 +1,7 @@
-catkin_add_nosetests(directed.py)
+find_package(ament_cmake_nose REQUIRED)
+find_package(ament_cmake_gtest REQUIRED)
 
-catkin_add_gtest(${PROJECT_NAME}-utest utest.cpp)
+ament_add_nose_test(directed.py .)
+
+ament_add_gtest(${PROJECT_NAME}-utest utest.cpp)
 target_link_libraries(${PROJECT_NAME}-utest ${PROJECT_NAME} ${OpenCV_LIBS})

--- a/image_geometry/test/CMakeLists.txt
+++ b/image_geometry/test/CMakeLists.txt
@@ -1,7 +1,8 @@
 find_package(ament_cmake_gtest REQUIRED)
-find_package(ament_cmake_pytest REQUIRED)
+# TODO(mikaelarguedas) Reenable this when tests are ported to ROS 2
+# find_package(ament_cmake_pytest REQUIRED)
 
-ament_add_pytest_test(directed.py .)
+# ament_add_pytest_test(directed.py "directed.py")
 
 ament_add_gtest(${PROJECT_NAME}-utest utest.cpp APPEND_LIBRARY_DIRS "${image_geometry_lib_dir}")
 target_link_libraries(${PROJECT_NAME}-utest ${PROJECT_NAME} ${OpenCV_LIBS})

--- a/image_geometry/test/directed.py
+++ b/image_geometry/test/directed.py
@@ -1,5 +1,3 @@
-import rostest
-import rospy
 import unittest
 import sensor_msgs.msg
 
@@ -67,9 +65,6 @@ class TestDirected(unittest.TestCase):
         self.assertAlmostEqual(cam.left.getDeltaY(dv, Z), xyz1[1] - xyz0[1], 3)
 
 if __name__ == '__main__':
-    if 1:
-        rostest.unitrun('image_geometry', 'directed', TestDirected)
-    else:
-        suite = unittest.TestSuite()
-        suite.addTest(TestDirected('test_stereo'))
-        unittest.TextTestRunner(verbosity=2).run(suite)
+    suite = unittest.TestSuite()
+    suite.addTest(TestDirected('test_stereo'))
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
This contributes the commits from https://github.com/ros2/vision_opencv to centralize all the vision_opencv packages ported to ROS 2 on this repository.

Related discussion https://github.com/ros2/vision_opencv/issues/13