### PR TITLE
`vision_opencv`: port metapackage to ROS 2

### DIFF
--- a/vision_opencv/CMakeLists.txt
+++ b/vision_opencv/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
+
 project(vision_opencv)
-find_package(catkin REQUIRED)
-catkin_metapackage()
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()

--- a/vision_opencv/package.xml
+++ b/vision_opencv/package.xml
@@ -1,9 +1,9 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
   <name>vision_opencv</name>
   <version>2.0.0</version>
   <description>Packages for interfacing ROS2 with OpenCV, a library of programming functions for real time computer vision.</description>
-  <author>Patrick Mihelich</author>
-  <author>James Bowman</author>
   <maintainer email="ethan.gao@linux.intel.com">Ethan Gao</maintainer>
   <license>BSD</license>
   
@@ -11,8 +11,13 @@
   <url type="bugtracker">https://github.com/ros-perception/vision_opencv/issues</url>
   <url type="repository">https://github.com/ros-perception/vision_opencv</url>
   
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>image_geometry</run_depend>
+  <author>Patrick Mihelich</author>
+  <author>James Bowman</author>
+  <author>Vincent Rabaud</author>
+
+  <exec_depend>cv_bridge</exec_depend>
+  <exec_depend>image_geometry</exec_depend>
+
   <export>
     <metapackage/>
   </export>

--- a/vision_opencv/package.xml
+++ b/vision_opencv/package.xml
@@ -15,11 +15,13 @@
   <author>James Bowman</author>
   <author>Vincent Rabaud</author>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>image_geometry</exec_depend>
 
   <export>
-    <metapackage/>
+    <build_type>ament_cmake</build_type>
   </export>
 
 </package>


### PR DESCRIPTION
I noticied https://github.com/ros-perception/vision_opencv/commit/da1d7dbe591d8949d5b07d1de50430ee93acd2a7 starting to port vision_opencv to ROS 2.

This PR follows-up and finishes the conversion of the `vision_opencv` metapackage to ROS 2.