### PR TITLE
backprojection of list of pixels in projectPixelTo3dRay

### DIFF
--- a/image_geometry/src/image_geometry/cameramodels.py
+++ b/image_geometry/src/image_geometry/cameramodels.py
@@ -136,7 +136,7 @@ class PinholeCameraModel:
         """
         x = (uv[0] - self.cx()) / self.fx()
         y = (uv[1] - self.cy()) / self.fy()
-        norm = math.sqrt(x*x + y*y + 1)
+        norm = numpy.sqrt(x*x + y*y + 1)
         x /= norm
         y /= norm
         z = 1.0 / norm


### PR DESCRIPTION
By using `numpy.sqrt()` instead of `math.sqrt()` the backprojection method `projectPixelTo3dRay()` can be used on a list of `uv` coordinates. This makes the call more efficient for backprojecting multiple pixels.