### PR TITLE
decode images in mode IMREAD_UNCHANGED

### DIFF
--- a/cv_bridge/python/cv_bridge/core.py
+++ b/cv_bridge/python/cv_bridge/core.py
@@ -124,7 +124,7 @@ class CvBridge(object):
         str_msg = cmprs_img_msg.data
         buf = np.ndarray(shape=(1, len(str_msg)),
                           dtype=np.uint8, buffer=cmprs_img_msg.data)
-        im = cv2.imdecode(buf, cv2.IMREAD_ANYCOLOR)
+        im = cv2.imdecode(buf, cv2.IMREAD_UNCHANGED)
 
         if desired_encoding == "passthrough":
             return im


### PR DESCRIPTION
This PR changes the decoding mode from `IMREAD_ANYCOLOR` to `IMREAD_UNCHANGED`.
With `IMREAD_ANYCOLOR` decompressing a 16bit png image results in an 8bit image.

Solves issues: https://github.com/ros-perception/vision_opencv/issues/206

This is a simple example of the conversion problem:
```Python
#!/usr/bin/env python3
from cv_bridge import CvBridge
import numpy as np
# create a 16bit depth image
im0 = np.empty(shape=(100, 100), dtype=np.uint16)
im0[:] = 2500 # 2.5m
print("original:", np.max(im0), im0.dtype)
# convert to compressed message
msg = CvBridge().cv2_to_compressed_imgmsg(im0, dst_format = "png")
# convert back to numpy array
im1 = CvBridge().compressed_imgmsg_to_cv2(msg)
print("converted:", np.max(im1), im1.dtype)
print("match?", np.all(im0==im1))
```

This example simply creates a 16bit depth image with the constant value of 2500mm and then convert this to a `sensor_msgs/CompressedImage` and back to a numpy array.

Currently, this conversion is broken:
```
original: 2500 uint16
converted: 9 uint8
match? False
```
This PR fixes this so that the content in `im0` and `im1` is identical:
```
original: 2500 uint16
converted: 2500 uint16
match? True
```