### PR TITLE
fix the build warning from inherent import numpy

### DIFF
--- a/cv_bridge/src/CMakeLists.txt
+++ b/cv_bridge/src/CMakeLists.txt
@@ -34,6 +34,9 @@ if(PYTHON_VERSION_MAJOR VERSION_EQUAL 3)
   add_definitions(-DPYTHON3)
 endif()
 
+#(TODO gaoethan: address the known warning in more elegant way. this is limited by
+# inherent system definiion to import numpy in module.hpp
+add_compile_options(-Wno-conversion-null -Wno-unused-function -Wno-return-type)
 if(OpenCV_VERSION_MAJOR VERSION_EQUAL 3)
   add_library(${PROJECT_NAME}_boost module.cpp module_opencv3.cpp)
 else()

--- a/cv_bridge/src/CMakeLists.txt
+++ b/cv_bridge/src/CMakeLists.txt
@@ -34,9 +34,6 @@ if(PYTHON_VERSION_MAJOR VERSION_EQUAL 3)
   add_definitions(-DPYTHON3)
 endif()
 
-#(TODO gaoethan: address the known warning in more elegant way. this is limited by
-# inherent system definiion to import numpy in module.hpp
-add_compile_options(-Wno-conversion-null -Wno-unused-function -Wno-return-type)
 if(OpenCV_VERSION_MAJOR VERSION_EQUAL 3)
   add_library(${PROJECT_NAME}_boost module.cpp module_opencv3.cpp)
 else()

--- a/cv_bridge/src/module.hpp
+++ b/cv_bridge/src/module.hpp
@@ -31,6 +31,16 @@ int convert_to_CvMat2(const PyObject * o, cv::Mat & m);
 
 PyObject * pyopencv_from(const cv::Mat & m);
 
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wconversion-null"
+# pragma clang diagnostic ignored "-Wreturn-type"
+#elif __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wconversion-null"
+# pragma GCC diagnostic ignored "-Wreturn-type"
+#endif
+
 #if PYTHON3
 static int do_numpy_import()
 {
@@ -41,6 +51,12 @@ static void do_numpy_import()
 {
   import_array();
 }
+#endif
+
+#ifdef __clang__
+# pragma clang diagnostic pop
+#elif __GNUC__
+# pragma GCC diagnostic pop
 #endif
 
 #endif  // MODULE_HPP_

--- a/cv_bridge/src/module_opencv3.cpp
+++ b/cv_bridge/src/module_opencv3.cpp
@@ -79,7 +79,8 @@ private:
 
 using namespace cv;
 
-static PyObject * failmsgp(const char * fmt, ...)
+
+[[gnu::unused]] static PyObject * failmsgp(const char * fmt, ...)
 {
   char str[1000];
 


### PR DESCRIPTION
There is build warning to complain the following:

```
In file included from /workspace/codebase/vision_opencv/cv_bridge/src/module_opencv3.cpp:3:0:
/workspace/codebase/vision_opencv/cv_bridge/src/module.hpp: In function 'int do_numpy_import()':
/workspace/codebase/vision_opencv/cv_bridge/src/module.hpp:37:3: warning: converting to non-pointer type 'int' from NULL [-Wconversion-null]
   import_array();
   ^~~~~~~~~~~~
/workspace/codebase/vision_opencv/cv_bridge/src/module.hpp:38:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
/workspace/codebase/vision_opencv/cv_bridge/src/module_opencv3.cpp: At global scope:
/workspace/codebase/vision_opencv/cv_bridge/src/module_opencv3.cpp:82:19: warning: 'PyObject* failmsgp(const char*, ...)' defined but not used [-Wunused-function]
 static PyObject * failmsgp(const char * fmt, ...)
                   ^~~~~~~~
In file included from /workspace/codebase/vision_opencv/cv_bridge/src/module.cpp:36:0:
/workspace/codebase/vision_opencv/cv_bridge/src/module.hpp: In function 'int do_numpy_import()':
/workspace/codebase/vision_opencv/cv_bridge/src/module.hpp:37:3: warning: converting to non-pointer type 'int' from NULL [-Wconversion-null]
   import_array();
   ^~~~~~~~~~~~
/workspace/codebase/vision_opencv/cv_bridge/src/module.hpp:38:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
```

But it's derived from the inherent definition for `import_array();` of numpy, so... fix this known warning to avoid error while package installation.