### PR TITLE
 Fix running exception of launch

### DIFF
--- a/opencv_tests/launch/view_img.py
+++ b/opencv_tests/launch/view_img.py
@@ -1,4 +1,4 @@
-from launch.exit_handler import default_exit_handler, restart_exit_handler
+from launch.legacy.exit_handler import default_exit_handler, restart_exit_handler
 from ros2run.api import get_executable_path
 
 

--- a/opencv_tests/setup.py
+++ b/opencv_tests/setup.py
@@ -6,13 +6,13 @@ package_name = 'opencv_tests'
 setup(
     name=package_name,
     version='0.4.0',
-    packages=find_packages(),
+    packages=find_packages(exclude=['launch']),
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
     ],
-    install_requires=['launch','setuptools'],
+    install_requires=['setuptools'],
     zip_safe=True,
     author='Ethan Gao',
     author_email='ethan.gao@linux.intel.com',


### PR DESCRIPTION
- fix exception of running `launch` cmdline after sourcing opencv_tests
- migrate launch to `launch.legacy` 