### PR TITLE
Move test dependencies into BUILD_TESTING to avoid build error

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -46,10 +46,9 @@ add_subdirectory(src)
 # This is overwritten each loop, but which one it points to doesn't really matter.
 set(cv_bridge_lib_dir "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
 
-find_package(ament_lint_auto REQUIRED)
-ament_lint_auto_find_test_dependencies()
-
 if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
   add_subdirectory(test)
 endif()
 

--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -47,8 +47,6 @@ add_subdirectory(src)
 set(cv_bridge_lib_dir "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
   add_subdirectory(test)
 endif()
 


### PR DESCRIPTION
Fix the issue in https://github.com/ros2/rosdistro/pull/260 due to some test dependencies that are find_package'd outside of a `BUILD_TESTING` conditional.