### PR TITLE
remove jp2 for test_encode_decode_cv2_compressed

### DIFF
--- a/cv_bridge/test/conversions.py
+++ b/cv_bridge/test/conversions.py
@@ -1,13 +1,10 @@
-import unittest
-
 from cv_bridge import CvBridge, CvBridgeError
 import numpy as np
-
+import unittest
 
 class TestConversions(unittest.TestCase):
 
     def test_mono16_cv2(self):
-        import numpy as np
         br = CvBridge()
         im = np.uint8(np.random.randint(0, 255, size=(480, 640, 3)))
         self.assertRaises(CvBridgeError, lambda: br.imgmsg_to_cv2(br.cv2_to_imgmsg(im), 'mono16'))
@@ -15,7 +12,6 @@ class TestConversions(unittest.TestCase):
 
     def test_encode_decode_cv2(self):
         import cv2
-        import numpy as np
         fmts = [cv2.CV_8U, cv2.CV_8S, cv2.CV_16U, cv2.CV_16S, cv2.CV_32S, cv2.CV_32F, cv2.CV_64F]
 
         cvb_en = CvBridge()
@@ -44,12 +40,10 @@ class TestConversions(unittest.TestCase):
     # http://docs.opencv.org/2.4/modules/highgui/doc/reading_and_writing_images_and_video.html#Mat
     # imread(const string& filename, int flags)
     def test_encode_decode_cv2_compressed(self):
-        import numpy as np
-        # from:
-        # http://docs.opencv.org/2.4/modules/highgui/doc/reading_and_writing_images_and_video.html#Mat
-        # imread(const string& filename, int flags)
+        # FIXME: remove jp2(a.k.a JPEG2000) as its JASPER codec is disabled within Ubuntu opencv library
+        # due to security issues, but it works once you rebuild your opencv library with JASPER enabled
         formats = ['jpg', 'jpeg', 'jpe', 'png', 'bmp', 'dib', 'ppm', 'pgm', 'pbm',
-                   'jp2', 'sr', 'ras', 'tif', 'tiff']  # this formats rviz is not support
+                   'sr', 'ras', 'tif', 'tiff']  # this formats rviz is not support
 
         cvb_en = CvBridge()
         cvb_de = CvBridge()


### PR DESCRIPTION
As JPEG2000 defaults to use JASPER as its codec,
but it's disabled within the opencv library after Ubutnu
Xenial due to security issues, one can enable to test 
after rebuilding opencv library with jasper enabled on
demand while necessary

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>