### PR TITLE
Ros2 revert handmade message initialization

### DIFF
--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -30,23 +30,6 @@ struct PinholeCameraModel::Cache
 
 PinholeCameraModel::PinholeCameraModel()
 {
-  cam_info_.header.stamp.sec = 0;
-  cam_info_.header.stamp.nanosec = 0;
-  cam_info_.header.frame_id = "";
-  cam_info_.height = 0;
-  cam_info_.width = 0;
-  cam_info_.distortion_model = "";
-  std::fill(cam_info_.d.begin(), cam_info_.d.end(), 0);
-  std::fill(cam_info_.k.begin(), cam_info_.k.end(), 0);
-  std::fill(cam_info_.r.begin(), cam_info_.r.end(), 0);
-  std::fill(cam_info_.p.begin(), cam_info_.p.end(), 0);
-  cam_info_.binning_x = 0;
-  cam_info_.binning_y = 0;
-  cam_info_.roi.x_offset = 0;
-  cam_info_.roi.y_offset = 0;
-  cam_info_.roi.height = 0;
-  cam_info_.roi.width = 0;
-  cam_info_.roi.do_rectify = false;
 }
 
 PinholeCameraModel& PinholeCameraModel::operator=(const PinholeCameraModel& other)

--- a/image_geometry/test/utest.cpp
+++ b/image_geometry/test/utest.cpp
@@ -27,21 +27,11 @@ protected:
                   0.0, 0.0, 1.0, 0.0};
 
 
-    cam_info_.header.stamp.sec = 0;
-    cam_info_.header.stamp.nanosec = 0;
     cam_info_.header.frame_id = "tf_frame";
     cam_info_.height = 480;
     cam_info_.width  = 640;
     cam_info_.distortion_model = sensor_msgs::distortion_models::PLUMB_BOB;
-    // No binning
-    cam_info_.binning_x = 0;
-    cam_info_.binning_y = 0;
     // No ROI
-    cam_info_.roi.x_offset = 0;
-    cam_info_.roi.y_offset = 0;
-    cam_info_.roi.height = 0;
-    cam_info_.roi.width = 0;
-    cam_info_.roi.do_rectify = false;
     cam_info_.d.resize(5);
     std::copy(D, D+5, cam_info_.d.begin());
     std::copy(K, K+9, cam_info_.k.begin());


### PR DESCRIPTION
Since https://github.com/ros2/rosidl/pull/236 the message are initialized automatically, these changes are not necessary anymore.

Related to https://github.com/ros2/ros2/issues/422