### PR TITLE
[Windows][melodic] remove path splash separator from 'package_dir'

### DIFF
--- a/cv_bridge/setup.py
+++ b/cv_bridge/setup.py
@@ -5,6 +5,6 @@ from catkin_pkg.python_setup import generate_distutils_setup
 d = generate_distutils_setup()
 
 d['packages'] = ['cv_bridge']
-d['package_dir'] = {'' : 'python/'}
+d['package_dir'] = {'' : 'python'}
 
 setup(**d)


### PR DESCRIPTION
When running catkin_make (or catkin_make_isolated) on Windows, `distutils` throws errors for `cv_bridge`. And it turned out that `distutils` doesn't like the path separator not matched to the underlying OS convention in `setup.py`.

```python
Traceback (most recent call last):
  File "C:/dr_ws/src/vision_opencv/cv_bridge\setup.py", line 11, in <module>
    setup(**d)
  File "C:\opt\python27amd64\lib\distutils\core.py", line 151, in setup
    dist.run_commands()
  File "C:\opt\python27amd64\lib\distutils\dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "C:\opt\python27amd64\lib\distutils\dist.py", line 972, in run_command
    cmd_obj.run()
  File "C:\opt\python27amd64\lib\distutils\command\build.py", line 127, in run
    self.run_command(cmd_name)
  File "C:\opt\python27amd64\lib\distutils\cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "C:\opt\python27amd64\lib\distutils\dist.py", line 971, in run_command
    cmd_obj.ensure_finalized()
  File "C:\opt\python27amd64\lib\distutils\cmd.py", line 109, in ensure_finalized
    self.finalize_options()
  File "C:\opt\python27amd64\lib\distutils\command\build_py.py", line 56, in finalize_options
    self.package_dir[name] = convert_path(path)
  File "C:\opt\python27amd64\lib\distutils\util.py", line 126, in convert_path
    raise ValueError, "path '%s' cannot end with '/'" % pathname
ValueError: path 'python/' cannot end with '/'
```

Per [the example in `catkin` doc](http://docs.ros.org/melodic/api/catkin/html/user_guide/setup_dot_py.html), it is not mandatory to tail the `package_dir` with `/` so it can be easily fixed by removing it and make the code more portable. 