### PR TITLE
[melodic] Fix travis CI

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -22,15 +22,16 @@ function travis_time_end {
     set -x
 }
 
-apt-get update -qq && apt-get install -qq -y -q wget sudo lsb-release # for docker 
+apt-get update -qq && apt-get install -y -q wget sudo lsb-release gnupg # for docker
+DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata # https://stackoverflow.com/questions/44331836/apt-get-install-tzdata-noninteractive
 
 travis_time_start setup.before_install
 #before_install:
 # Define some config vars.
 # Install ROS
-sudo sh -c "echo \"deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main\" > /etc/apt/sources.list.d/ros-latest.list"
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-sudo apt-get update -qq
+sudo apt-get update -qq || echo Ignore error on apt-get update
 # Install ROS
 sudo apt-get install -qq -y python-catkin-pkg python-catkin-tools python-rosdep python-wstool ros-$ROS_DISTRO-catkin
 source /opt/ros/$ROS_DISTRO/setup.bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: generic
 env:
-  - ROS_DISTRO=kinetic
+  - ROS_DISTRO=melodic
 # Install system dependencies, namely ROS.
 before_install:
   # Define some config vars.
@@ -11,7 +11,7 @@ before_install:
   - export ROS_PARALLEL_JOBS='-j8 -l6'
 script:
   - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-  - docker run --rm -i -v $CI_SOURCE_PATH:$CI_SOURCE_PATH -e "CI_SOURCE_PATH=$CI_SOURCE_PATH" -e "HOME=$HOME" -e "ROS_DISTRO=$ROS_DISTRO" -e "ROS_PARALLEL_JOBS=$ROS_PARALLEL_JOBS" -t ubuntu:xenial sh -c "cd $CI_SOURCE_PATH; ./.travis.sh"
+  - docker run --rm -i -v $CI_SOURCE_PATH:$CI_SOURCE_PATH -e "CI_SOURCE_PATH=$CI_SOURCE_PATH" -e "HOME=$HOME" -e "ROS_DISTRO=$ROS_DISTRO" -e "ROS_PARALLEL_JOBS=$ROS_PARALLEL_JOBS" -t ubuntu:bionic sh -c "cd $CI_SOURCE_PATH; ./.travis.sh"
 after_failure:
   - find ${HOME}/.ros/test_results -type f -exec echo "== {} ==" \; -exec cat {} \;
   - for file in ${HOME}/.ros/log/rostest-*; do echo "=== $file ==="; cat $file; done

--- a/cv_bridge/test/conversions.py
+++ b/cv_bridge/test/conversions.py
@@ -47,8 +47,10 @@ class TestConversions(unittest.TestCase):
     def test_encode_decode_cv2_compressed(self):
         import numpy as np
         # from: http://docs.opencv.org/2.4/modules/highgui/doc/reading_and_writing_images_and_video.html#Mat imread(const string& filename, int flags)
+        # NOTE: remove jp2(a.k.a JPEG2000) as its JASPER codec is disabled within Ubuntu opencv library
+        # due to security issues, but it works once you rebuild your opencv library with JASPER enabled
         formats = ["jpg", "jpeg", "jpe", "png", "bmp", "dib", "ppm", "pgm", "pbm",
-                   "jp2", "sr", "ras", "tif", "tiff"]  # this formats rviz is not support
+                   "sr", "ras", "tif", "tiff"]  # this formats rviz is not support
 
         cvb_en = CvBridge()
         cvb_de = CvBridge()


### PR DESCRIPTION
Fix travis CI build for melodic. The change is adapted from https://github.com/tork-a/visualization_rwt/commit/4a9390641bafeeaf7ce6eadbd627b9469043d16d.

One standing error is `test_encode_decode_cv2_compressed` failure, which is also reproducible on `Mpr__vision_opencv__ubuntu_bionic_amd64` build.
```python
======================================================================
ERROR: test_encode_decode_cv2_compressed (conversions.TestConversions)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/catkin_ws/src/vision_opencv/cv_bridge/test/conversions.py", line 64, in test_encode_decode_cv2_compressed
    compress_rosmsg = cvb_en.cv2_to_compressed_imgmsg(original, f)
  File "/home/travis/catkin_ws/src/vision_opencv/cv_bridge/python/cv_bridge/core.py", line 219, in cv2_to_compressed_imgmsg
    cmprs_img_msg.data = np.array(cv2.imencode(ext_format, cvim)[1]).tostring()
error: /build/opencv-L2vuMj/opencv-3.2.0+dfsg/modules/imgcodecs/src/loadsave.cpp:783: error: (-2) could not find encoder for the specified extension in function imencode
```