### PR TITLE
Fix Boost Python 2/3 for old and new Boost.

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -3,16 +3,18 @@ project(cv_bridge)
 
 find_package(catkin REQUIRED COMPONENTS rosconsole sensor_msgs)
 
+find_package(Boost QUIET)
 if(NOT ANDROID)
-  find_package(PythonLibs)
-  if(PYTHONLIBS_VERSION_STRING VERSION_LESS 3)
-    find_package(Boost REQUIRED python)
+  if(Boost_VERSION LESS 106700)
+    set(BOOST_PYTHON_COMPONENT_SUFFIX "-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
   else()
-    find_package(Boost REQUIRED python3)
+    set(BOOST_PYTHON_COMPONENT_SUFFIX "${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
   endif()
+  find_package(Boost REQUIRED COMPONENTS python${BOOST_PYTHON_COMPONENT_SUFFIX})
 else()
-find_package(Boost REQUIRED)
+  find_package(Boost REQUIRED)
 endif()
+
 find_package(OpenCV 3 REQUIRED
   COMPONENTS
     opencv_core

--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -3,8 +3,10 @@ project(cv_bridge)
 
 find_package(catkin REQUIRED COMPONENTS rosconsole sensor_msgs)
 
-find_package(Boost QUIET)
 if(NOT ANDROID)
+  find_package(PythonLibs REQUIRED)
+  find_package(PythonInterp REQUIRED)
+  find_package(Boost QUIET)
   if(Boost_VERSION LESS 106700)
     set(BOOST_PYTHON_COMPONENT_SUFFIX "-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
   else()


### PR DESCRIPTION
This is a simpler version of #239.

I have validated this with Python 2 and Python 3 on Xenial, so I know it works in that scenario (where the proposed solution from #239 does not work for Python 3). And I believe it should work for Boost 1.67+ as well, based on the original fix.

@meyerj @NikolausDemmel @vrabaud 