### PR TITLE
silence unused return value warnings

### DIFF
--- a/cv_bridge/test/utest2.cpp
+++ b/cv_bridge/test/utest2.cpp
@@ -122,7 +122,7 @@ TEST(OpencvTests, testCase_encode_decode)
           }
           cv_image = cv_bridge::toCvShare(image_msg, dst_encoding);
           // We cannot convert from non-color to color
-          EXPECT_THROW(cvtColor(cv_image, src_encoding)->image, cv_bridge::Exception);
+          EXPECT_THROW((void)cvtColor(cv_image, src_encoding)->image, cv_bridge::Exception);
           continue;
         }
         // We do not support conversion to YUV422 for now, except from YUV422
@@ -135,7 +135,7 @@ TEST(OpencvTests, testCase_encode_decode)
 
         // We do not support conversion to YUV422 for now, except from YUV422
         if ((src_encoding == YUV422) && (dst_encoding != YUV422)) {
-          EXPECT_THROW(cvtColor(cv_image, src_encoding)->image, cv_bridge::Exception);
+          EXPECT_THROW((void)cvtColor(cv_image, src_encoding)->image, cv_bridge::Exception);
           continue;
         }
       }


### PR DESCRIPTION
I get "unused-result-value" warnings when building this on OSX.  The `(void)` should suffice to silence these warnings.

Signed-off-by: Karsten Knese <karsten@openrobotics.org>