### PR TITLE
[ros2] Suppress boost python warning

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -21,7 +21,15 @@ if(NOT ANDROID)
     if(Boost_VERSION LESS 106500)
       find_package(Boost REQUIRED python)
     else()
-      find_package(Boost REQUIRED python3)
+      # This is a bit of a hack to suppress a warning
+      #   No header defined for python3; skipping header check
+      # Which should only affect Boost versions < 1.67
+      # Resolution for newer versions:
+      #  https://gitlab.kitware.com/cmake/cmake/issues/16391
+      if (Boost_VERSION LESS 106700)
+        set(_Boost_PYTHON3_HEADERS "boost/python.hpp")
+      endif()
+      find_package(Boost COMPONENTS python3 REQUIRED)
     endif()
   endif()
 else()


### PR DESCRIPTION
This suppresses a cmake warning:
```
No header defined for python3; skipping header check
```

Which should only appear on Boost versions < 1.67
Full resolution for newer versions of Boost: https://gitlab.kitware.com/cmake/cmake/issues/16391

The longer term goal would be to remove the dependency on Boost Python entirely here, if possible.