### PR TITLE
Fix for case when left.Tx() != 0

### DIFF
--- a/image_geometry/include/image_geometry/stereo_camera_model.h
+++ b/image_geometry/include/image_geometry/stereo_camera_model.h
@@ -110,19 +110,19 @@ inline const cv::Matx44d& StereoCameraModel::reprojectionMatrix() const { return
 inline double StereoCameraModel::baseline() const
 {
   /// @todo Currently assuming horizontal baseline
-  return -right_.Tx() / right_.fx();
+  return (left_.Tx() - right_.Tx()) / right_.fx();
 }
 
 inline double StereoCameraModel::getZ(double disparity) const
 {
   assert( initialized() );
-  return -right_.Tx() / (disparity - (left().cx() - right().cx()));
+  return (left_.Tx() - right_.Tx()) / (disparity - (left().cx() - right().cx()));
 }
 
 inline double StereoCameraModel::getDisparity(double Z) const
 {
   assert( initialized() );
-  return -right_.Tx() / Z + (left().cx() - right().cx()); ;
+  return (left_.Tx() - right_.Tx()) / Z + (left().cx() - right().cx()); ;
 }
 
 } //namespace image_geometry


### PR DESCRIPTION
Such a case is possible when using more than two cameras. For example, KITTI projection matrices for color cameras.