### PR TITLE
fix for endian mismatch issue per boostorg/python PR #218

### DIFF
--- a/cv_bridge/src/module.hpp
+++ b/cv_bridge/src/module.hpp
@@ -37,6 +37,7 @@ PyObject* pyopencv_from(const cv::Mat& m);
 static int do_numpy_import( )
 {
     import_array( );
+    return NULL;
 }
 #else
 static void do_numpy_import( )


### PR DESCRIPTION
Greetings,

I'm on a team maintanining arch linux packages for ROS and someone just ran into [this issue](https://github.com/ros-melodic-arch/ros-melodic-cv-bridge/issues/1). Namely, upon import the user gets:
```
RuntimeError: FATAL: module compiled as little endian, but detected different endianness at runtime
```

In googling around, I found [this](https://github.com/boostorg/python/issues/209) and [this](https://github.com/pni-libraries/python-pni/issues/73) which were handled by PRs [boostorg/python 218](https://github.com/boostorg/python/pull/218) and [python-pni 74](https://github.com/pni-libraries/python-pni/pull/74). Both were the same, and appear based on [this explanation](https://github.com/boostorg/python/pull/218#issue-200647888).

I grepped for `import_array`, added the `return NULL` statement, rebuilt, and I no longer get the import error.