### PR TITLE
Updated fromCameraInfo function to match ROS2 CameraInfo message

### DIFF
--- a/image_geometry/image_geometry/cameramodels.py
+++ b/image_geometry/image_geometry/cameramodels.py
@@ -39,15 +39,15 @@ class PinholeCameraModel:
 
         Set the camera parameters from the :class:`sensor_msgs.msg.CameraInfo` message.
         """
-        self.K = mkmat(3, 3, msg.K)
-        if msg.D:
-            self.D = mkmat(len(msg.D), 1, msg.D)
+        self.K = mkmat(3, 3, msg.k)
+        if msg.d:
+            self.D = mkmat(len(msg.d), 1, msg.d)
         else:
             self.D = None
-        self.R = mkmat(3, 3, msg.R)
-        self.P = mkmat(3, 4, msg.P)
-        self.full_K = mkmat(3, 3, msg.K)
-        self.full_P = mkmat(3, 4, msg.P)
+        self.R = mkmat(3, 3, msg.r)
+        self.P = mkmat(3, 4, msg.p)
+        self.full_K = mkmat(3, 3, msg.k)
+        self.full_P = mkmat(3, 4, msg.p)
         self.width = msg.width
         self.height = msg.height
         self.binning_x = max(1, msg.binning_x)


### PR DESCRIPTION
Hi all,

While testing packages that make use of the image_geometry functionality (i.e. the camera_calibration package) I found out that the function fromCameraInfo uses the old definition of ROS message for CameraInfo, where K, D, R and P were uppercase hence it crashed.
I fixed it by changing them to the lowercase version.

While this makes the code "work" I'm open to feedback on whether we should also rename all the class variables to follow the same convention, having more consistency but at the risk of breaking user code that relies on the current one.

Cheers,
/Luca