### PR TITLE
[Windows][ros2] Export interfaces for Shared Lib on Windows

### DIFF
--- a/cv_bridge/include/cv_bridge/cv_bridge.h
+++ b/cv_bridge/include/cv_bridge/cv_bridge.h
@@ -46,11 +46,12 @@
 #include <stdexcept>
 #include <string>
 #include <memory>
+#include <cv_bridge/cv_bridge_export.h>
 
 namespace cv_bridge
 {
 
-class Exception : public std::runtime_error
+class CV_BRIDGE_EXPORT Exception : public std::runtime_error
 {
 public:
   explicit Exception(const std::string & description)
@@ -79,7 +80,7 @@ typedef enum
  * \brief Image message class that is interoperable with sensor_msgs/Image but uses a
  * more convenient cv::Mat representation for the image data.
  */
-class CvImage
+class CV_BRIDGE_EXPORT CvImage
 {
 public:
   std_msgs::msg::Header header;  // !< ROS header
@@ -147,7 +148,7 @@ protected:
 
   /// @cond DOXYGEN_IGNORE
   friend
-  CvImageConstPtr toCvShare(
+  CV_BRIDGE_EXPORT CvImageConstPtr toCvShare(
     const sensor_msgs::msg::Image & source,
     const std::shared_ptr<void const> & tracked_object,
     const std::string & encoding);
@@ -171,11 +172,11 @@ protected:
  * If \a encoding is the empty string (the default), the returned CvImage has the same encoding
  * as \a source.
  */
-CvImagePtr toCvCopy(
+CV_BRIDGE_EXPORT CvImagePtr toCvCopy(
   const sensor_msgs::msg::Image::ConstSharedPtr & source,
   const std::string & encoding = std::string());
 
-CvImagePtr toCvCopy(
+CV_BRIDGE_EXPORT CvImagePtr toCvCopy(
   const sensor_msgs::msg::CompressedImage::ConstSharedPtr & source,
   const std::string & encoding = std::string());
 
@@ -198,11 +199,11 @@ CvImagePtr toCvCopy(
  * 255/65535 respectively). Otherwise, no scaling is applied and the rules from the convertTo OpenCV
  * function are applied (capping): http://docs.opencv.org/modules/core/doc/basic_structures.html#mat-convertto
  */
-CvImagePtr toCvCopy(
+CV_BRIDGE_EXPORT CvImagePtr toCvCopy(
   const sensor_msgs::msg::Image & source,
   const std::string & encoding = std::string());
 
-CvImagePtr toCvCopy(
+CV_BRIDGE_EXPORT CvImagePtr toCvCopy(
   const sensor_msgs::msg::CompressedImage & source,
   const std::string & encoding = std::string());
 
@@ -226,7 +227,7 @@ CvImagePtr toCvCopy(
  * If \a encoding is the empty string (the default), the returned CvImage has the same encoding
  * as \a source.
  */
-CvImageConstPtr toCvShare(
+CV_BRIDGE_EXPORT CvImageConstPtr toCvShare(
   const sensor_msgs::msg::Image::ConstSharedPtr & source,
   const std::string & encoding = std::string());
 
@@ -254,7 +255,7 @@ CvImageConstPtr toCvShare(
  * If \a encoding is the empty string (the default), the returned CvImage has the same encoding
  * as \a source.
  */
-CvImageConstPtr toCvShare(
+CV_BRIDGE_EXPORT CvImageConstPtr toCvShare(
   const sensor_msgs::msg::Image & source,
   const std::shared_ptr<void const> & tracked_object,
   const std::string & encoding = std::string());
@@ -262,7 +263,7 @@ CvImageConstPtr toCvShare(
 /**
  * \brief Convert a CvImage to another encoding using the same rules as toCvCopy
  */
-CvImagePtr cvtColor(
+CV_BRIDGE_EXPORT CvImagePtr cvtColor(
   const CvImageConstPtr & source,
   const std::string & encoding);
 
@@ -313,7 +314,7 @@ struct CvtColorForDisplayOptions
  * - max_image_value Maximum image value
  * - colormap Colormap which the source image converted with.
  */
-CvImageConstPtr cvtColorForDisplay(
+CV_BRIDGE_EXPORT CvImageConstPtr cvtColorForDisplay(
   const CvImageConstPtr & source,
   const std::string & encoding = std::string(),
   const CvtColorForDisplayOptions options = CvtColorForDisplayOptions());
@@ -323,7 +324,7 @@ CvImageConstPtr cvtColorForDisplay(
  *
  * For example, "bgr8" -> CV_8UC3, "32FC1" -> CV_32FC1, and "32FC10" -> CV_32FC10.
  */
-int getCvType(const std::string & encoding);
+CV_BRIDGE_EXPORT int getCvType(const std::string & encoding);
 
 }  // namespace cv_bridge
 

--- a/cv_bridge/include/cv_bridge/rgb_colors.h
+++ b/cv_bridge/include/cv_bridge/rgb_colors.h
@@ -37,6 +37,7 @@
 #define CV_BRIDGE__RGB_COLORS_H_
 
 #include <opencv2/opencv.hpp>
+#include <cv_bridge/cv_bridge_export.h>
 
 
 namespace cv_bridge
@@ -203,7 +204,7 @@ enum Colors
  * @brief
  * get rgb color with enum.
  */
-cv::Vec3d getRGBColor(const int color);
+CV_BRIDGE_EXPORT cv::Vec3d getRGBColor(const int color);
 
 }  // namespace rgb_colors
 

--- a/cv_bridge/src/CMakeLists.txt
+++ b/cv_bridge/src/CMakeLists.txt
@@ -1,5 +1,8 @@
 # add library
 add_library(${PROJECT_NAME} cv_bridge.cpp rgb_colors.cpp)
+include(GenerateExportHeader)
+generate_export_header(${PROJECT_NAME} EXPORT_FILE_NAME ${PROJECT_NAME}/${PROJECT_NAME}_export.h)
+target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
 ament_target_dependencies(${PROJECT_NAME}
   "OpenCV"
   "sensor_msgs"
@@ -7,6 +10,10 @@ ament_target_dependencies(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${OpenCV_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}_export.h
+  DESTINATION include/${PROJECT_NAME})
 
 if(NOT ANDROID)
 # add a Boost Python library


### PR DESCRIPTION
On Windows, for a shared library, the interfaces must be explicitly decorated by proper `dllimport` and `dllexport` usage. Otherwise, no imported library (.lib) will be generated for the downstream projects to consume at link time.

This pull request is to add the interface export in a portable way provided by `CMake` (instead of directly using MSVC specific `dllimport` and `dllexport`).

This is a rework for https://github.com/ros-perception/vision_opencv/pull/277