### PR TITLE
Add conversions for YUY2 (YUYV) encoding

### DIFF
--- a/cv_bridge/src/cv_bridge.cpp
+++ b/cv_bridge/src/cv_bridge.cpp
@@ -97,6 +97,7 @@ int getCvType(const std::string & encoding)
 
   // Miscellaneous
   if (encoding == enc::YUV422) {return CV_8UC2;}
+  if (encoding == enc::YUV422_YUY2) {return CV_8UC2;}
 
   // Check all the generic content encodings
   std::cmatch m;
@@ -118,7 +119,7 @@ int getCvType(const std::string & encoding)
 
 /// @cond DOXYGEN_IGNORE
 
-enum Encoding { INVALID = -1, GRAY = 0, RGB, BGR, RGBA, BGRA, YUV422, BAYER_RGGB, BAYER_BGGR,
+enum Encoding { INVALID = -1, GRAY = 0, RGB, BGR, RGBA, BGRA, YUV422, YUV422_YUY2, BAYER_RGGB, BAYER_BGGR,
   BAYER_GBRG, BAYER_GRBG};
 
 Encoding getEncoding(const std::string & encoding)
@@ -129,6 +130,7 @@ Encoding getEncoding(const std::string & encoding)
   if ((encoding == enc::BGRA8) || (encoding == enc::BGRA16)) {return BGRA;}
   if ((encoding == enc::RGBA8) || (encoding == enc::RGBA16)) {return RGBA;}
   if (encoding == enc::YUV422) {return YUV422;}
+  if (encoding == enc::YUV422_YUY2) {return YUV422_YUY2;}
 
   if ((encoding == enc::BAYER_RGGB8) || (encoding == enc::BAYER_RGGB16)) {return BAYER_RGGB;}
   if ((encoding == enc::BAYER_BGGR8) || (encoding == enc::BAYER_BGGR16)) {return BAYER_BGGR;}
@@ -183,6 +185,12 @@ std::map<std::pair<Encoding, Encoding>, std::vector<int>> getConversionCodes()
   res[std::make_pair(YUV422, RGBA)].push_back(cv::COLOR_YUV2RGBA_UYVY);
   res[std::make_pair(YUV422, BGRA)].push_back(cv::COLOR_YUV2BGRA_UYVY);
 
+  res[std::make_pair(YUV422_YUY2, GRAY)].push_back(cv::COLOR_YUV2GRAY_YUY2);
+  res[std::make_pair(YUV422_YUY2, RGB)].push_back(cv::COLOR_YUV2RGB_YUY2);
+  res[std::make_pair(YUV422_YUY2, BGR)].push_back(cv::COLOR_YUV2BGR_YUY2);
+  res[std::make_pair(YUV422_YUY2, RGBA)].push_back(cv::COLOR_YUV2RGBA_YUY2);
+  res[std::make_pair(YUV422_YUY2, BGRA)].push_back(cv::COLOR_YUV2BGRA_YUY2);
+
   // Deal with Bayer
   res[std::make_pair(BAYER_RGGB, GRAY)].push_back(cv::COLOR_BayerBG2GRAY);
   res[std::make_pair(BAYER_RGGB, RGB)].push_back(cv::COLOR_BayerBG2RGB);
@@ -208,9 +216,9 @@ const std::vector<int> getConversionCode(std::string src_encoding, std::string d
   Encoding src_encod = getEncoding(src_encoding);
   Encoding dst_encod = getEncoding(dst_encoding);
   bool is_src_color_format = enc::isColor(src_encoding) || enc::isMono(src_encoding) ||
-    enc::isBayer(src_encoding) || (src_encoding == enc::YUV422);
+    enc::isBayer(src_encoding) || (src_encoding == enc::YUV422) || (src_encoding == enc::YUV422_YUY2);
   bool is_dst_color_format = enc::isColor(dst_encoding) || enc::isMono(dst_encoding) ||
-    enc::isBayer(dst_encoding) || (dst_encoding == enc::YUV422);
+    enc::isBayer(dst_encoding) || (dst_encoding == enc::YUV422) || (dst_encoding == enc::YUV422_YUY2);
   bool is_num_channels_the_same =
     (enc::numChannels(src_encoding) == enc::numChannels(dst_encoding));
 

--- a/cv_bridge/test/utest2.cpp
+++ b/cv_bridge/test/utest2.cpp
@@ -71,8 +71,8 @@ getEncodings()
     TYPE_64FC1, /*TYPE_64FC2,*/ TYPE_64FC3, TYPE_64FC4,
     // BAYER_RGGB8, BAYER_BGGR8, BAYER_GBRG8, BAYER_GRBG8,
     // BAYER_RGGB16, BAYER_BGGR16, BAYER_GBRG16, BAYER_GRBG16,
-    YUV422};
-  return std::vector<std::string>(encodings, encodings + 47 - 8 - 7);
+    YUV422, YUV422_YUY2};
+  return std::vector<std::string>(encodings, encodings + 48 - 8 - 7);
 }
 
 TEST(OpencvTests, testCase_encode_decode)
@@ -81,7 +81,8 @@ TEST(OpencvTests, testCase_encode_decode)
   for (size_t i = 0; i < encodings.size(); ++i) {
     std::string src_encoding = encodings[i];
     bool is_src_color_format = isColor(src_encoding) || isMono(src_encoding) ||
-      (src_encoding == sensor_msgs::image_encodings::YUV422);
+      (src_encoding == sensor_msgs::image_encodings::YUV422) ||
+      (src_encoding == sensor_msgs::image_encodings::YUV422_YUY2);
     cv::Mat image_original(cv::Size(400, 400), cv_bridge::getCvType(src_encoding));
     cv::RNG r(77);
     r.fill(image_original, cv::RNG::UNIFORM, 0, 127);
@@ -95,7 +96,8 @@ TEST(OpencvTests, testCase_encode_decode)
     for (size_t j = 0; j < encodings.size(); ++j) {
       std::string dst_encoding = encodings[j];
       bool is_dst_color_format = isColor(dst_encoding) || isMono(dst_encoding) ||
-        (dst_encoding == sensor_msgs::image_encodings::YUV422);
+        (dst_encoding == sensor_msgs::image_encodings::YUV422) ||
+        (dst_encoding == sensor_msgs::image_encodings::YUV422_YUY2);
       bool is_num_channels_the_same = (numChannels(src_encoding) == numChannels(dst_encoding));
 
       cv_bridge::CvImageConstPtr cv_image;
@@ -126,7 +128,8 @@ TEST(OpencvTests, testCase_encode_decode)
           continue;
         }
         // We do not support conversion to YUV422 for now, except from YUV422
-        if ((dst_encoding == YUV422) && (src_encoding != YUV422)) {
+        if (((dst_encoding == YUV422) && (src_encoding != YUV422)) ||
+          ((dst_encoding == YUV422_YUY2) && (src_encoding != YUV422_YUY2))) {
           EXPECT_THROW(cv_bridge::toCvShare(image_msg, dst_encoding), cv_bridge::Exception);
           continue;
         }
@@ -134,7 +137,8 @@ TEST(OpencvTests, testCase_encode_decode)
         cv_image = cv_bridge::toCvShare(image_msg, dst_encoding);
 
         // We do not support conversion to YUV422 for now, except from YUV422
-        if ((src_encoding == YUV422) && (dst_encoding != YUV422)) {
+        if (((src_encoding == YUV422) && (dst_encoding != YUV422)) ||
+            ((src_encoding == YUV422_YUY2) && (dst_encoding != YUV422_YUY2))){
           EXPECT_THROW((void)cvtColor(cv_image, src_encoding)->image, cv_bridge::Exception);
           continue;
         }


### PR DESCRIPTION
In https://github.com/ros2/common_interfaces/pull/78 the `yuv422_yuy2` image encoding was added, which is the format commonly coming out of webcams.

This PR adds conversions from this format, in line with the existing `yuv422` ones for UYVY.