### PR TITLE
[ros2] use more specific boost rosdep keys

### DIFF
--- a/cv_bridge/package.xml
+++ b/cv_bridge/package.xml
@@ -21,12 +21,15 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>python_cmake_module</buildtool_depend>
 
-  <depend>boost</depend>
+  <build_depend>libboost-dev</build_depend>
+  <build_depend>libboost-python-dev</build_depend>
+
   <depend>libopencv-dev</depend>
   <depend>python3-numpy</depend>
   <depend>sensor_msgs</depend>
 
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>libboost-python</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>


### PR DESCRIPTION
Restrict the rosdep keys to pull only the necessary boost libraries

This is currently the only package in ROS 2 desktop pulling all boost libraries.
Requires https://github.com/ros/rosdistro/pull/23844