### PR TITLE
[Noetic] Use opencv3 on buster

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -5,7 +5,14 @@ find_package(catkin REQUIRED COMPONENTS rosconsole sensor_msgs)
 
 if(NOT ANDROID)
   find_package(PythonLibs)
-  find_package(Boost REQUIRED python)
+
+  if(PYTHONLIBS_VERSION_STRING VERSION_LESS "3.8")
+    # Debian Buster
+    find_package(Boost REQUIRED python37)
+  else()
+    # Ubuntu Focal
+    find_package(Boost REQUIRED python)
+  endif()
 else()
 find_package(Boost REQUIRED)
 endif()

--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -9,7 +9,15 @@ if(NOT ANDROID)
 else()
 find_package(Boost REQUIRED)
 endif()
-find_package(OpenCV 4 REQUIRED
+
+set(_opencv_version 4)
+find_package(OpenCV 4 QUIET)
+if(NOT OpenCV_FOUND)
+  message(STATUS "Did not find OpenCV 4, trying OpenCV 3")
+  set(_opencv_version 3)
+endif()
+
+find_package(OpenCV ${_opencv_version4} REQUIRED
   COMPONENTS
     opencv_core
     opencv_imgproc

--- a/cv_bridge/src/module_opencv4.cpp
+++ b/cv_bridge/src/module_opencv4.cpp
@@ -90,6 +90,11 @@ static PyObject* failmsgp(const char *fmt, ...)
 
 class NumpyAllocator : public MatAllocator
 {
+#if CV_MAJOR_VERSION == 3
+protected:
+    typedef int AccessFlag;
+#endif
+
 public:
     NumpyAllocator() { stdAllocator = Mat::getStdAllocator(); }
     ~NumpyAllocator() {}

--- a/cv_bridge/test/conversions.py
+++ b/cv_bridge/test/conversions.py
@@ -63,7 +63,6 @@ class TestConversions(unittest.TestCase):
                             original = np.uint8(np.random.randint(0, 255, size=(h, w)))
                         else:
                             original = np.uint8(np.random.randint(0, 255, size=(h, w, channels)))
-                        print(f)
                         compress_rosmsg = cvb_en.cv2_to_compressed_imgmsg(original, f)
                         newimg          = cvb_de.compressed_imgmsg_to_cv2(compress_rosmsg)
                         self.assert_(original.dtype == newimg.dtype)


### PR DESCRIPTION
ROS Noetic uses OpenCV 4 on Focal, but OpenCV 3.2 on Buster: https://www.ros.org/reps/rep-0003.html#noetic-ninjemys-may-2020-may-2025

* Removes debug print added in #323 
* If OpenCV 4 isn't available, try finding 3
* Typedef `AccessFlag` type added in OpenCV 4 if using 3.2
* Use different boost python component names on Buster vs Focal

~~I'm opening this PR a bit early; I'm unable to successfully run tests on my system because the cvtColorForDisplay test fails; but the import is strange. I'm wondering if it will work in the PR job:~~

**Edit** Tests pass; ready for review and hopefully merge and release :rocket: