### PR TITLE
Add missing return statement in numpy import

### DIFF
--- a/cv_bridge/src/module.hpp
+++ b/cv_bridge/src/module.hpp
@@ -42,9 +42,10 @@ PyObject * pyopencv_from(const cv::Mat & m);
 #endif
 
 #if PYTHON3
-static int do_numpy_import()
+static void * do_numpy_import()
 {
   import_array();
+  return NULL;
 }
 #else
 static void do_numpy_import()


### PR DESCRIPTION
Forward port of #292

This reflects a patch made in https://github.com/boostorg/python/pull/218
I've also updated the return signature to match upstream.

Fixes https://github.com/ros-perception/vision_opencv/issues/339

---

Note, to reproduce the reported error I first built `vision_opencv` with `-DCMAKE_BUILD_TYPE=Release` and then overlayed the [`camera_calibration`](https://github.com/ros-perception/image_pipeline/tree/ros2) package and ran it's tests.