### PR TITLE
Implement unrectifyImage()

### DIFF
--- a/image_geometry/include/image_geometry/pinhole_camera_model.h
+++ b/image_geometry/include/image_geometry/pinhole_camera_model.h
@@ -107,6 +107,7 @@ public:
    * \return 3d ray passing through (u,v)
    */
   cv::Point3d projectPixelTo3dRay(const cv::Point2d& uv_rect) const;
+  cv::Point3d projectPixelTo3dRay(const cv::Point2d& uv_rect, const cv::Matx34d& P) const;
 
   /**
    * \brief Rectify a raw camera image.
@@ -124,11 +125,13 @@ public:
    * \brief Compute the rectified image coordinates of a pixel in the raw image.
    */
   cv::Point2d rectifyPoint(const cv::Point2d& uv_raw) const;
+  cv::Point2d rectifyPoint(const cv::Point2d& uv_raw, const cv::Matx33d& K, const cv::Matx34d& P) const;
 
   /**
    * \brief Compute the raw image coordinates of a pixel in the rectified image.
    */
   cv::Point2d unrectifyPoint(const cv::Point2d& uv_rect) const;
+  cv::Point2d unrectifyPoint(const cv::Point2d& uv_rect, const cv::Matx33d& K, const cv::Matx34d& P) const;
 
   /**
    * \brief Compute the rectified ROI best fitting a raw ROI.

--- a/image_geometry/include/image_geometry/pinhole_camera_model.h
+++ b/image_geometry/include/image_geometry/pinhole_camera_model.h
@@ -278,6 +278,7 @@ protected:
 #endif
 
   void initRectificationMaps() const;
+  void initUnrectificationMaps() const;
 
   friend class StereoCameraModel;
 };

--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -23,6 +23,12 @@ struct PinholeCameraModel::Cache
   mutable bool reduced_maps_dirty;
   mutable cv::Mat reduced_map1, reduced_map2;
 
+  mutable bool unrectify_full_maps_dirty;
+  mutable cv::Mat unrectify_full_map1, unrectify_full_map2;
+
+  mutable bool unrectify_reduced_maps_dirty;
+  mutable cv::Mat unrectify_reduced_map1, unrectify_reduced_map2;
+
   mutable bool rectified_roi_dirty;
   mutable cv::Rect rectified_roi;
 
@@ -31,6 +37,8 @@ struct PinholeCameraModel::Cache
       distortion_model(UNKNOWN_MODEL),
       full_maps_dirty(true),
       reduced_maps_dirty(true),
+      unrectify_full_maps_dirty(true),
+      unrectify_reduced_maps_dirty(true),
       rectified_roi_dirty(true)
   {
   }
@@ -112,7 +120,7 @@ bool PinholeCameraModel::fromCameraInfo(const sensor_msgs::CameraInfo& msg)
 
   // Update any parameters that have changed. The full rectification maps are
   // invalidated by any change in the calibration parameters OR binning.
-  bool &full_dirty = cache_->full_maps_dirty;
+  bool full_dirty = false;
   full_dirty |= update(msg.height, cam_info_.height);
   full_dirty |= update(msg.width,  cam_info_.width);
   full_dirty |= update(msg.distortion_model, cam_info_.distortion_model);
@@ -122,16 +130,22 @@ bool PinholeCameraModel::fromCameraInfo(const sensor_msgs::CameraInfo& msg)
   full_dirty |= updateMat(msg.P, cam_info_.P, P_full_);
   full_dirty |= update(binning_x, cam_info_.binning_x);
   full_dirty |= update(binning_y, cam_info_.binning_y);
+  cache_->full_maps_dirty |= full_dirty;
+  cache_->unrectify_full_maps_dirty |= full_dirty;
 
   // The reduced rectification maps are invalidated by any of the above or a
   // change in ROI.
-  bool &reduced_dirty = cache_->reduced_maps_dirty;
-  reduced_dirty  = full_dirty;
+  bool reduced_dirty = full_dirty;
   reduced_dirty |= update(roi.x_offset,   cam_info_.roi.x_offset);
   reduced_dirty |= update(roi.y_offset,   cam_info_.roi.y_offset);
   reduced_dirty |= update(roi.height,     cam_info_.roi.height);
   reduced_dirty |= update(roi.width,      cam_info_.roi.width);
   reduced_dirty |= update(roi.do_rectify, cam_info_.roi.do_rectify);
+  cache_->reduced_maps_dirty |= reduced_dirty;
+  cache_->reduced_maps_dirty |= cache_->full_maps_dirty;
+  cache_->unrectify_reduced_maps_dirty |= reduced_dirty;
+  cache_->unrectify_reduced_maps_dirty |= cache_->unrectify_full_maps_dirty;
+
   // As is the rectified ROI
   cache_->rectified_roi_dirty = reduced_dirty;
 
@@ -335,14 +349,24 @@ void PinholeCameraModel::unrectifyImage(const cv::Mat& rectified, cv::Mat& raw, 
 {
   assert( initialized() );
 
-  throw Exception("PinholeCameraModel::unrectifyImage is unimplemented.");
-  /// @todo Implement unrectifyImage()
-  // Similar to rectifyImage, but need to build separate set of inverse maps (raw->rectified)...
-  // - Build src_pt Mat with all the raw pixel coordinates (or do it one row at a time)
-  // - Do cv::undistortPoints(src_pt, dst_pt, K_, D_, R_, P_)
-  // - Use convertMaps() to convert dst_pt to fast fixed-point maps
-  // - cv::remap(rectified, raw, ...)
-  // Need interpolation argument. Same caching behavior?
+  switch (cache_->distortion_state) {
+    case NONE:
+      rectified.copyTo(raw);
+      break;
+    case CALIBRATED:
+      initUnrectificationMaps();
+      if (rectified.depth() == CV_32F || rectified.depth() == CV_64F)
+      {
+        cv::remap(rectified, raw, cache_->unrectify_reduced_map1, cache_->unrectify_reduced_map2, interpolation, cv::BORDER_CONSTANT, std::numeric_limits<float>::quiet_NaN());
+      }
+      else {
+        cv::remap(rectified, raw, cache_->unrectify_reduced_map1, cache_->unrectify_reduced_map2, interpolation);
+      }
+      break;
+    default:
+      assert(cache_->distortion_state == UNKNOWN);
+      throw Exception("Cannot call rectifyImage when distortion is unknown.");
+  }
 }
 
 cv::Point2d PinholeCameraModel::rectifyPoint(const cv::Point2d& uv_raw) const
@@ -528,6 +552,86 @@ void PinholeCameraModel::initRectificationMaps() const
       cache_->reduced_map2 = cache_->full_map2;
     }
     cache_->reduced_maps_dirty = false;
+  }
+}
+
+void PinholeCameraModel::initUnrectificationMaps() const
+{
+  /// @todo For large binning settings, can drop extra rows/cols at bottom/right boundary.
+  /// Make sure we're handling that 100% correctly.
+
+  if (cache_->unrectify_full_maps_dirty) {
+    // Create the full-size map at the binned resolution
+    /// @todo Should binned resolution, K, P be part of public API?
+    cv::Size binned_resolution = fullResolution();
+    binned_resolution.width  /= binningX();
+    binned_resolution.height /= binningY();
+
+    cv::Matx33d K_binned;
+    cv::Matx34d P_binned;
+    if (binningX() == 1 && binningY() == 1) {
+      K_binned = K_full_;
+      P_binned = P_full_;
+    }
+    else {
+      K_binned = K_full_;
+      P_binned = P_full_;
+      if (binningX() > 1) {
+        double scale_x = 1.0 / binningX();
+        K_binned(0,0) *= scale_x;
+        K_binned(0,2) *= scale_x;
+        P_binned(0,0) *= scale_x;
+        P_binned(0,2) *= scale_x;
+        P_binned(0,3) *= scale_x;
+      }
+      if (binningY() > 1) {
+        double scale_y = 1.0 / binningY();
+        K_binned(1,1) *= scale_y;
+        K_binned(1,2) *= scale_y;
+        P_binned(1,1) *= scale_y;
+        P_binned(1,2) *= scale_y;
+        P_binned(1,3) *= scale_y;
+      }
+    }
+
+    cv::Mat float_map_x(binned_resolution.height, binned_resolution.width, CV_32FC1);
+    cv::Mat float_map_y(binned_resolution.height, binned_resolution.width, CV_32FC1);
+    for (size_t x = 0; x < binned_resolution.width; x++) {
+      for (size_t y = 0; y < binned_resolution.height; y++) {
+        cv::Point2f uv_raw(x, y), uv_rect;
+        uv_rect = rectifyPoint(uv_raw, K_binned, P_binned);
+        float_map_x.at<float>(y, x) = uv_rect.x;
+        float_map_y.at<float>(y, x) = uv_rect.y;
+      }
+    }
+    // Note: m1type=CV_16SC2 to use fast fixed-point maps (see cv::remap)
+    convertMaps(float_map_x, float_map_y, cache_->unrectify_full_map1, cache_->unrectify_full_map2, CV_16SC2);
+    cache_->unrectify_full_maps_dirty = false;
+  }
+
+  if (cache_->unrectify_reduced_maps_dirty) {
+    /// @todo Use rectified ROI
+    cv::Rect roi(cam_info_.roi.x_offset, cam_info_.roi.y_offset,
+                 cam_info_.roi.width, cam_info_.roi.height);
+    if (roi.x != 0 || roi.y != 0 ||
+        (roi.height != 0 && roi.height != (int)cam_info_.height) ||
+        (roi.width != 0 && roi.width  != (int)cam_info_.width)) {
+
+      // map1 contains integer (x,y) offsets, which we adjust by the ROI offset
+      // map2 contains LUT index for subpixel interpolation, which we can leave as-is
+      roi.x /= binningX();
+      roi.y /= binningY();
+      roi.width  /= binningX();
+      roi.height /= binningY();
+      cache_->unrectify_reduced_map1 = cache_->unrectify_full_map1(roi) - cv::Scalar(roi.x, roi.y);
+      cache_->unrectify_reduced_map2 = cache_->unrectify_full_map2(roi);
+    }
+    else {
+      // Otherwise we're rectifying the full image
+      cache_->unrectify_reduced_map1 = cache_->unrectify_full_map1;
+      cache_->unrectify_reduced_map2 = cache_->unrectify_full_map2;
+    }
+    cache_->unrectify_reduced_maps_dirty = false;
   }
 }
 

--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -556,8 +556,8 @@ void PinholeCameraModel::initRectificationMaps() const
     cv::Rect roi(cam_info_.roi.x_offset, cam_info_.roi.y_offset,
                  cam_info_.roi.width, cam_info_.roi.height);
     if (roi.x != 0 || roi.y != 0 ||
-        roi.height != (int)cam_info_.height ||
-        roi.width  != (int)cam_info_.width) {
+        (roi.height != 0 && roi.height != (int)cam_info_.height) ||
+        (roi.width != 0 && roi.width  != (int)cam_info_.width)) {
 
       // map1 contains integer (x,y) offsets, which we adjust by the ROI offset
       // map2 contains LUT index for subpixel interpolation, which we can leave as-is


### PR DESCRIPTION
This PR removes the "PinholeCameraModel::unrectifyImage is unimplemented" exception and actually implements the function! :)

Closes #355.

I have also added a unit test. This PR works just fine when no ROI is set in the camera_info message. However, I am unsure how to handle the ROI here. As far as I can tell, since we are doing unrectification, i.e., processing an already rectified image, the ROI is not relevant here.

**Question to the maintainers:** Do we need to handle the ROI for unrectifying images?

* If **yes**, I'll have to address the part marked `// TODO: use K_binned, P_binned, binned_resolution`. I have copied most of the ROI handling code over from `initRectificationMaps`; only the part where these three variables are actually used has to be fixed.
* If **no**, I'll remove all the unnecessary ROI handling code and simplify the PR.