### PR TITLE
Fix multiple undefined references

### DIFF
--- a/cv_bridge/test/CMakeLists.txt
+++ b/cv_bridge/test/CMakeLists.txt
@@ -22,6 +22,7 @@ ament_add_gtest(${PROJECT_NAME}-utest
 target_link_libraries(${PROJECT_NAME}-utest
   ${PROJECT_NAME}
   ${OpenCV_LIBRARIES}
+  ${PYTHON_LIBRARIES}
 )
 
 # enable cv_bridge python tests


### PR DESCRIPTION
As discussion in [318](https://github.com/ros-perception/vision_opencv/issues/318) and [364](https://github.com/ros-perception/vision_opencv/issues/364). This change should be pulled.