### PR TITLE
Updated cameramodels.py

### DIFF
--- a/image_geometry/src/image_geometry/cameramodels.py
+++ b/image_geometry/src/image_geometry/cameramodels.py
@@ -7,7 +7,7 @@ import copy
 import numpy
 
 def mkmat(rows, cols, L):
-    mat = numpy.matrix(L, dtype='float64')
+    mat = numpy.array(L, dtype='float64')
     mat.resize((rows,cols))
     return mat
 
@@ -116,7 +116,7 @@ class PinholeCameraModel:
         This is the inverse of :meth:`projectPixelTo3dRay`.
         """
         src = mkmat(4, 1, [point[0], point[1], point[2], 1.0])
-        dst = self.P * src
+        dst = self.P @ src
         x = dst[0,0]
         y = dst[1,0]
         w = dst[2,0]


### PR DESCRIPTION
For ROS Noetic, at line 10 the following error is thrown:
```
error: File "/opt/ros/noetic/lib/python3/dist-packages/image_geometry/cameramodels.py", line 10, in mkmat
    mat = numpy.matrix(L, dtype='float64')
```
Changed `numpy.matrix` to `numpy.array`. 

In line 119, it throws the following error:
```
error File "/opt/ros/noetic/lib/python3/dist-packages/image_geometry/cameramodels.py", line 120, in project3dToPixel
    dst = self.P * src
ValueError: operands could not be broadcast together with shapes (3,4) (4,1) 
```
Changed it to `dst = self.P @ src`