### PR TITLE
fix windows build for image_geometry

### DIFF
--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -18,7 +18,9 @@ endif()
 find_package(OpenCV REQUIRED COMPONENTS calib3d core highgui imgproc)
 find_package(sensor_msgs REQUIRED)
 
-include_directories(include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${OpenCV_INCLUDE_DIRS}
+)
 
 # add a library
 add_library(${PROJECT_NAME}


### PR DESCRIPTION
just tested this and it closes #387 .

successful windows build log for `image_geometry` ros2 branch:

```
-- Selecting Windows SDK version 10.0.18362.0 to target Windows 10.0.18363.
-- Found ament_cmake_python: 0.9.8 (C:/opt/ros/foxy/x64/share/ament_cmake_python/cmake)
-- Found ament_cmake_ros: 0.9.0 (C:/opt/ros/foxy/x64/share/ament_cmake_ros/cmake)
-- Using PYTHON_EXECUTABLE: C:/opt/ros/foxy/x64/python.exe
-- OpenCV ARCH: x64
-- OpenCV RUNTIME: vc16
-- OpenCV STATIC: OFF
-- Found OpenCV 3.4.6 in C:/opencv/x64/vc16/lib
-- You might need to add C:\opencv\x64\vc16\bin to your PATH to be able to run your applications.
-- Found sensor_msgs: 2.0.3 (C:/opt/ros/foxy/x64/share/sensor_msgs/cmake)
-- Using all available rosidl_typesupport_c: rosidl_typesupport_fastrtps_c;rosidl_typesupport_introspection_c
-- Found rosidl_adapter: 1.2.0 (C:/opt/ros/foxy/x64/share/rosidl_adapter/cmake)
-- Using all available rosidl_typesupport_cpp: rosidl_typesupport_fastrtps_cpp;rosidl_typesupport_introspection_cpp
-- openCV libraries cmake variable: opencv_calib3d;opencv_core;opencv_highgui;opencv_imgproc
-- Found gtest sources under 'C:/opt/ros/foxy/x64/src/gtest_vendor': C++ tests using 'Google Test' will be built
-- Configuring done
-- Generating done
-- Build files have been written to: D:/code/ros/rolling/build/image_geometry
Microsoft (R) Build Engine version 16.9.0+5e4b48a27 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  pinhole_camera_model.cpp
  stereo_camera_model.cpp
     Creating library D:/code/ros/rolling/build/image_geometry/Release/image_geometry.lib and object D:/code/ros/rolling/build/image_geometry/Release/image_geometry.exp
  image_geometry.vcxproj -> D:\code\ros\rolling\build\image_geometry\Release\image_geometry.dll
  gtest-all.cc
  gtest.vcxproj -> D:\code\ros\rolling\build\image_geometry\gtest\Release\gtest.lib
  gtest_main.cc
  gtest_main.vcxproj -> D:\code\ros\rolling\build\image_geometry\gtest\Release\gtest_main.lib
  Building Custom Rule D:/code/ros/rolling/src/vision_opencv/image_geometry/test/CMakeLists.txt
  utest.cpp
  image_geometry-utest.vcxproj -> D:\code\ros\rolling\build\image_geometry\test\Release\image_geometry-utest.exe
  Building Custom Rule D:/code/ros/rolling/src/vision_opencv/image_geometry/CMakeLists.txt
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/environment/pythonpath.bat
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/environment/pythonpath.dsv
-- Installing: D:/code/ros/rolling/install/image_geometry/Lib/site-packages/image_geometry
-- Installing: D:/code/ros/rolling/install/image_geometry/Lib/site-packages/image_geometry/cameramodels.py
-- Installing: D:/code/ros/rolling/install/image_geometry/Lib/site-packages/image_geometry/__init__.py
Listing 'D:/code/ros/rolling/install/image_geometry/Lib/site-packages/image_geometry'...
Compiling 'D:/code/ros/rolling/install/image_geometry/Lib/site-packages/image_geometry\\__init__.py'...
Compiling 'D:/code/ros/rolling/install/image_geometry/Lib/site-packages/image_geometry\\cameramodels.py'...
-- Installing: D:/code/ros/rolling/install/image_geometry/include/image_geometry
-- Installing: D:/code/ros/rolling/install/image_geometry/include/image_geometry/pinhole_camera_model.h
-- Installing: D:/code/ros/rolling/install/image_geometry/include/image_geometry/stereo_camera_model.h
-- Installing: D:/code/ros/rolling/install/image_geometry/include/image_geometry/visibility_control.hpp
-- Installing: D:/code/ros/rolling/install/image_geometry/lib/image_geometry.lib
-- Installing: D:/code/ros/rolling/install/image_geometry/bin/image_geometry.dll
-- Installing: D:/code/ros/rolling/install/image_geometry/share/ament_index/resource_index/package_run_dependencies/image_geometry
-- Installing: D:/code/ros/rolling/install/image_geometry/share/ament_index/resource_index/parent_prefix_path/image_geometry
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/environment/ament_prefix_path.bat
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/environment/ament_prefix_path.dsv
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/environment/path.bat
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/environment/path.dsv
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/local_setup.bat
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/local_setup.dsv
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/package.dsv
-- Installing: D:/code/ros/rolling/install/image_geometry/share/ament_index/resource_index/packages/image_geometry
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/cmake/ament_cmake_export_libraries-extras.cmake
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/cmake/ament_cmake_export_dependencies-extras.cmake
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/cmake/ament_cmake_export_include_directories-extras.cmake
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/cmake/image_geometryConfig.cmake
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/cmake/image_geometryConfig-version.cmake
-- Installing: D:/code/ros/rolling/install/image_geometry/share/image_geometry/package.xml
```