### PR TITLE
Export sensor_msgs dependency

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -71,7 +71,10 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-ament_export_dependencies(OpenCV)
+ament_export_dependencies(
+  OpenCV
+  sensor_msgs
+)
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})


### PR DESCRIPTION
Otherwise, packages that include cv_bridge.h will get a build error if they do not explicitly link against sensor_msgs.

---

For example, the following ament project will not build:

_CMakeLists.txt_
```
cmake_minimum_required(VERSION 3.8)
project(foo)

find_package(ament_cmake REQUIRED)
find_package(cv_bridge REQUIRED)

add_executable(foo src/foo.cpp)
ament_target_dependencies(foo cv_bridge)

ament_package()
```

_foo.cpp_
```
#include <cv_bridge/cv_bridge.h>

int main(void)
{
  return 0;
}
```