### PR TITLE
Handle padded img msg python

### DIFF
--- a/cv_bridge/python/cv_bridge/core.py
+++ b/cv_bridge/python/cv_bridge/core.py
@@ -175,11 +175,11 @@ class CvBridge(object):
         if n_channels == 1:
             im = np.ndarray(shape=(img_msg.height, img_msg.step/dtype.itemsize),
                             dtype=dtype, buffer=img_buf)
-            im = np.ascontiguousarray(im[:img_msg.height, img_msg.width])
+            im = np.ascontiguousarray(im[:img_msg.height, :img_msg.width])
         else:
             im = np.ndarray(shape=(img_msg.height, img_msg.step/dtype.itemsize/n_channels, n_channels),
                             dtype=dtype, buffer=img_buf)
-            im = np.ascontiguousarray(im[:img_msg.height, img_msg.width, :])
+            im = np.ascontiguousarray(im[:img_msg.height, :img_msg.width, :])
 
         # If the byte order is different between the message and the system.
         if img_msg.is_bigendian == (sys.byteorder == 'little'):

--- a/cv_bridge/python/cv_bridge/core.py
+++ b/cv_bridge/python/cv_bridge/core.py
@@ -173,12 +173,15 @@ class CvBridge(object):
         img_buf = np.asarray(img_msg.data, dtype=dtype) if isinstance(img_msg.data, list) else img_msg.data
 
         if n_channels == 1:
-            im = np.ndarray(shape=(img_msg.height, img_msg.width),
+            im = np.ndarray(shape=(img_msg.height, img_msg.step/dtype.itemsize),
                             dtype=dtype, buffer=img_buf)
+            im = np.ascontiguousarray(im[:img_msg.height, img_msg.width])
         else:
-            im = np.ndarray(shape=(img_msg.height, img_msg.width, n_channels),
+            im = np.ndarray(shape=(img_msg.height, img_msg.step/dtype.itemsize/n_channels, n_channels),
                             dtype=dtype, buffer=img_buf)
-        # If the byt order is different between the message and the system.
+            im = np.ascontiguousarray(im[:img_msg.height, img_msg.width, :])
+
+        # If the byte order is different between the message and the system.
         if img_msg.is_bigendian == (sys.byteorder == 'little'):
             im = im.byteswap().newbyteorder()
 

--- a/cv_bridge/python/cv_bridge/core.py
+++ b/cv_bridge/python/cv_bridge/core.py
@@ -173,11 +173,11 @@ class CvBridge(object):
         img_buf = np.asarray(img_msg.data, dtype=dtype) if isinstance(img_msg.data, list) else img_msg.data
 
         if n_channels == 1:
-            im = np.ndarray(shape=(img_msg.height, img_msg.step/dtype.itemsize),
+            im = np.ndarray(shape=(img_msg.height, int(img_msg.step/dtype.itemsize)),
                             dtype=dtype, buffer=img_buf)
             im = np.ascontiguousarray(im[:img_msg.height, :img_msg.width])
         else:
-            im = np.ndarray(shape=(img_msg.height, img_msg.step/dtype.itemsize/n_channels, n_channels),
+            im = np.ndarray(shape=(img_msg.height, int(img_msg.step/dtype.itemsize/n_channels), n_channels),
                             dtype=dtype, buffer=img_buf)
             im = np.ascontiguousarray(im[:img_msg.height, :img_msg.width, :])
 


### PR DESCRIPTION
Images coming off some V4L2 cameras have padding at the end of each line, which results in incorrect matrix generation by the python version of the [imgmsg_to_cv2](https://github.com/ros-perception/vision_opencv/blob/7df66485d409d1fce67c437643e06e95f7800575/cv_bridge/python/cv_bridge/core.py#L147) function.

![test_image](https://user-images.githubusercontent.com/52378223/123671198-6461ab00-d814-11eb-8bd8-6128a09267f8.jpg)

The `bytesperline` attribute of the [v4l2_pix_format](https://www.kernel.org/doc/html/v4.14/media/uapi/v4l/pixfmt-v4l2.html) structure specifies the number of bytes between the leftmost pixels in two adjacent lines. This `bytesperline` value is then stored in the `step` attribute of the [Image](https://docs.ros.org/en/api/sensor_msgs/html/msg/Image.html) message.

This fix uses the the `step` value to generate the "correct" shaped matrix, after which the matrix is cropped to the required image `width` and `height`.