### PR TITLE
fix endianness comparison

### DIFF
--- a/cv_bridge/src/cv_bridge.cpp
+++ b/cv_bridge/src/cv_bridge.cpp
@@ -431,7 +431,7 @@ CvImageConstPtr toCvShare(
   const std::string & encoding)
 {
   // If the encoding different or the endianness different, you have to copy
-  if ((!encoding.empty() && source.encoding != encoding) || (source.is_bigendian &&
+  if ((!encoding.empty() && source.encoding != encoding) || (!source.is_bigendian !=
     (boost::endian::order::native != boost::endian::order::big)))
   {
     return toCvCopy(source, encoding);


### PR DESCRIPTION
Rebased [PR#310](https://github.com/ros-perception/vision_opencv/pull/310) on latest ros2. Tested on foxy, passes all tests.