### PR TITLE
fix build error with ubuntu18-ros2(#406)

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -85,11 +85,6 @@ install(
   DESTINATION include/${PROJECT_NAME}
 )
 
-install(TARGETS ${PROJECT_NAME}
-        RUNTIME DESTINATION bin
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-)
 
 ament_package(
   CONFIG_EXTRAS "cmake/cv_bridge-extras.cmake.in"


### PR DESCRIPTION
This fix building error on branch ros2, while working on Ubuntu-18.04

related issue [#406](https://github.com/ros-perception/vision_opencv/issues/406)

Signed-off-by: dukun <dukun1@xiaomi.com>