### PR TITLE
substituted missing sphinx extension to fix Python docs

### DIFF
--- a/image_geometry/doc/conf.py
+++ b/image_geometry/doc/conf.py
@@ -22,7 +22,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.pngmath']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.imgmath']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
This should let the python docs be built again. 
I noticed while trying to browse the docs @ http://docs.ros.org/en/noetic/api/image_geometry/html/python that they probably could not be built and thus cannot be shown. This should fix that - at least it does so on my local install with a rosdoc_lite for the local docs.