### PR TITLE
Install includes to include/${PROJECT_NAME} and more modern CMake

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(cv_bridge)
 
 find_package(ament_cmake_ros REQUIRED)
@@ -33,7 +33,7 @@ if(NOT ANDROID)
     endif()
   endif()
 else()
-  find_package(Boost REQUIRED)
+  find_package(Boost REQUIRED COMPONENTS python)
 endif()
 
 find_package(sensor_msgs REQUIRED)
@@ -76,14 +76,10 @@ ament_export_dependencies(
   sensor_msgs
 )
 
-ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 
 # install the include folder
-install(
-  DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION include/${PROJECT_NAME}
-)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION bin

--- a/cv_bridge/src/CMakeLists.txt
+++ b/cv_bridge/src/CMakeLists.txt
@@ -2,17 +2,19 @@
 add_library(${PROJECT_NAME} cv_bridge.cpp rgb_colors.cpp)
 include(GenerateExportHeader)
 generate_export_header(${PROJECT_NAME} EXPORT_FILE_NAME ${PROJECT_NAME}/${PROJECT_NAME}_export.h)
-target_include_directories(${PROJECT_NAME}
-  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
-  ${PROJECT_SOURCE_DIR}/include
-  ${Boost_INCLUDE_DIRS})
-ament_target_dependencies(${PROJECT_NAME}
-  "OpenCV"
-  "sensor_msgs"
-)
-target_link_libraries(${PROJECT_NAME} ${PYTHON_LIBRARIES} ${Boost_LIBRARIES} ${OpenCV_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${sensor_msgs_TARGETS}
+  opencv_core
+  opencv_imgproc
+  opencv_imgcodecs)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  Boost::headers)
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -20,56 +22,25 @@ install(TARGETS ${PROJECT_NAME}
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}_export.h
-  DESTINATION include/${PROJECT_NAME})
+  DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME})
 
 if(NOT ANDROID)
-# add a Boost Python library
-find_package(PythonInterp REQUIRED)
-find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
+  find_package(Python3 REQUIRED COMPONENTS Development NumPy)
 
-# Get the numpy include directory from its python module
-if(NOT PYTHON_NUMPY_INCLUDE_DIR)
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import numpy; print(numpy.get_include())"
-    RESULT_VARIABLE PYTHON_NUMPY_PROCESS
-    OUTPUT_VARIABLE PYTHON_NUMPY_INCLUDE_DIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  Python3_add_library(${PROJECT_NAME}_boost MODULE module.cpp module_opencv3.cpp)
+  target_link_libraries(${PROJECT_NAME}_boost PRIVATE
+    ${PROJECT_NAME}
+    Boost::python
+    Python3::NumPy)
+  target_compile_definitions(${PROJECT_NAME}_boost PRIVATE PYTHON3)
 
-  if(PYTHON_NUMPY_PROCESS EQUAL 0)
-    file(TO_CMAKE_PATH "${PYTHON_NUMPY_INCLUDE_DIR}" PYTHON_NUMPY_INCLUDE_CMAKE_PATH)
-    set(PYTHON_NUMPY_INCLUDE_DIR ${PYTHON_NUMPY_INCLUDE_CMAKE_PATH} CACHE PATH "Numpy include directory")
-  else()
-    message(SEND_ERROR "Could not determine the NumPy include directory, verify that NumPy was installed correctly.")
+  if(OpenCV_VERSION_MAJOR VERSION_EQUAL 4)
+    target_compile_definitions(${PROJECT_NAME}_boost PRIVATE OPENCV_VERSION_4)
   endif()
-endif()
 
-include_directories(${PYTHON_INCLUDE_PATH} ${PYTHON_NUMPY_INCLUDE_DIR})
-
-if(PYTHON_VERSION_MAJOR VERSION_EQUAL 3)
-  add_definitions(-DPYTHON3)
-endif()
-
-if(OpenCV_VERSION_MAJOR VERSION_EQUAL 4)
-  add_definitions(-DOPENCV_VERSION_4)
-endif()
-
-if(OpenCV_VERSION_MAJOR VERSION_LESS 3)
-  add_library(${PROJECT_NAME}_boost module.cpp module_opencv2.cpp)
-else()
-  add_library(${PROJECT_NAME}_boost module.cpp module_opencv3.cpp)
-endif()
-target_link_libraries(${PROJECT_NAME}_boost
-  ${PYTHON_LIBRARIES}
-  ${PROJECT_NAME}
-)
-
-set_target_properties(${PROJECT_NAME}_boost PROPERTIES
-                      LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/boost/
-                      PREFIX ""
-)
-if(APPLE)
   set_target_properties(${PROJECT_NAME}_boost PROPERTIES
-                        SUFFIX ".so")
-endif()
-
-install(TARGETS ${PROJECT_NAME}_boost DESTINATION ${PYTHON_INSTALL_DIR}/${PROJECT_NAME}/boost/)
+                        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/boost/
+                        PREFIX ""
+  )
+  install(TARGETS ${PROJECT_NAME}_boost DESTINATION ${PYTHON_INSTALL_DIR}/${PROJECT_NAME}/boost/)
 endif()

--- a/cv_bridge/test/CMakeLists.txt
+++ b/cv_bridge/test/CMakeLists.txt
@@ -21,8 +21,10 @@ ament_add_gtest(${PROJECT_NAME}-utest
   APPEND_LIBRARY_DIRS "${cv_bridge_lib_dir}")
 target_link_libraries(${PROJECT_NAME}-utest
   ${PROJECT_NAME}
-  ${OpenCV_LIBRARIES}
-)
+  Boost::headers
+  opencv_core
+  opencv_imgcodecs
+  ${sensor_msgs_TARGETS})
 
 # enable cv_bridge python tests
 find_package(ament_cmake_pytest REQUIRED)

--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -18,47 +18,40 @@ endif()
 find_package(OpenCV REQUIRED COMPONENTS calib3d core highgui imgproc)
 find_package(sensor_msgs REQUIRED)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${OpenCV_INCLUDE_DIRS}
-)
-
-# add a library
 add_library(${PROJECT_NAME}
-  src/pinhole_camera_model.cpp src/stereo_camera_model.cpp
+  src/pinhole_camera_model.cpp
+  src/stereo_camera_model.cpp
 )
-target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES})
-ament_target_dependencies(
-  ${PROJECT_NAME}
-  OpenCV
-  sensor_msgs
-)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  opencv_calib3d
+  opencv_core
+  opencv_highgui
+  opencv_imgproc
+  ${sensor_msgs_TARGETS})
 
-install(DIRECTORY include/${PROJECT_NAME}/
-        DESTINATION include/${PROJECT_NAME}
-)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "IMAGE_GEOMETRY_BUILDING_DLL")
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
         RUNTIME DESTINATION bin
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
 )
 
-# image_geometry_lib_dir is passed as APPEND_LIBRARY_DIRS for each ament_add_gtest call so
-# the project library that they link against is on the library path.
-# This is especially important on Windows.
-# This is overwritten each loop, but which one it points to doesn't really matter.
-set(image_geometry_lib_dir "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
-
-# add tests
 if(BUILD_TESTING)
-  add_subdirectory(test)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(${PROJECT_NAME}-utest test/utest.cpp)
+  target_link_libraries(${PROJECT_NAME}-utest ${PROJECT_NAME})
 endif()
 
-ament_export_libraries(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(OpenCV)
-ament_export_include_directories(include)
+ament_export_dependencies(sensor_msgs)
+
 ament_package()

--- a/image_geometry/test/CMakeLists.txt
+++ b/image_geometry/test/CMakeLists.txt
@@ -4,5 +4,5 @@ find_package(ament_cmake_gtest REQUIRED)
 
 # ament_add_pytest_test(directed.py "directed.py")
 
-ament_add_gtest(${PROJECT_NAME}-utest utest.cpp APPEND_LIBRARY_DIRS "${image_geometry_lib_dir}")
-target_link_libraries(${PROJECT_NAME}-utest ${PROJECT_NAME} ${OpenCV_LIBS})
+ament_add_gtest(${PROJECT_NAME}-utest utest.cpp)
+target_link_libraries(${PROJECT_NAME}-utest ${PROJECT_NAME})


### PR DESCRIPTION
This PR has quite a bit. It could probably be split into smaller PRs.

Part of ros2/ros2#1150

This installs includes to `include/${PROJECT_NAME}` to mitigate include directory search order issues when overriding packages in desktop.

Part of ament/ament_cmake#365

This removes `ament_export_libraries` and `ament_export_include_directories` as they're redundant with the exported CMake targets.

Part of ament/ament_cmake#292

This replaces `ament_target_dependencies()` calls with `target_link_libraries()`.

Part of ros2/python_cmake_module#6

This uses FindPython3 instead of the deprecated FindPythonInterp and FindPythonLibs.

I think it also removes support for OpenCV 2 and earlier

