### PR TITLE
Forward-port PRs from noetic to ros2

### DIFF
--- a/cv_bridge/python/cv_bridge/core.py
+++ b/cv_bridge/python/cv_bridge/core.py
@@ -236,7 +236,7 @@ class CvBridge(object):
 
         return cmprs_img_msg
 
-    def cv2_to_imgmsg(self, cvim, encoding='passthrough'):
+    def cv2_to_imgmsg(self, cvim, encoding='passthrough', header = None):
         """
         Convert an OpenCV :cpp:type:`cv::Mat` type to a ROS sensor_msgs::Image message.
 
@@ -245,6 +245,7 @@ class CvBridge(object):
 
            * ``"passthrough"``
            * one of the standard strings in sensor_msgs/image_encodings.h
+        :param header:    A std_msgs.msg.Header message
 
         :rtype:           A sensor_msgs.msg.Image message
         :raises CvBridgeError: when the ``cvim`` has a type that is incompatible with ``encoding``
@@ -261,6 +262,8 @@ class CvBridge(object):
         img_msg = sensor_msgs.msg.Image()
         img_msg.height = cvim.shape[0]
         img_msg.width = cvim.shape[1]
+        if header is not None:
+            img_msg.header = header
         if len(cvim.shape) < 3:
             cv_type = self.dtype_with_channels_to_cvtype2(cvim.dtype, 1)
         else:

--- a/cv_bridge/src/cv_bridge.cpp
+++ b/cv_bridge/src/cv_bridge.cpp
@@ -515,7 +515,8 @@ void CvImage::toCompressedImageMsg(
 {
   ros_image.header = header;
   cv::Mat image;
-  if (encoding == enc::BGR8 || encoding == enc::BGRA8) {
+  if (encoding == enc::BGR8 || encoding == enc::BGRA8  || encoding == enc::MONO8 || encoding == enc::MONO16)
+  {
     image = this->image;
   } else {
     CvImagePtr tempThis = std::make_shared<CvImage>(*this);
@@ -548,18 +549,24 @@ CvImagePtr toCvCopy(const sensor_msgs::msg::CompressedImage & source, const std:
   // Loads as BGR or BGRA.
   const cv::Mat rgb_a = cv::imdecode(in, cv::IMREAD_UNCHANGED);
 
-  switch (rgb_a.channels()) {
-    case 4:
-      return toCvCopyImpl(rgb_a, source.header, enc::BGRA8, encoding);
-      break;
-    case 3:
-      return toCvCopyImpl(rgb_a, source.header, enc::BGR8, encoding);
-      break;
-    case 1:
-      return toCvCopyImpl(rgb_a, source.header, enc::MONO8, encoding);
-      break;
-    default:
-      return CvImagePtr();
+  if (encoding != enc::MONO16) {
+    switch (rgb_a.channels())
+    {
+      case 4:
+        return toCvCopyImpl(rgb_a, source.header, enc::BGRA8, encoding);
+        break;
+      case 3:
+        return toCvCopyImpl(rgb_a, source.header, enc::BGR8, encoding);
+        break;
+      case 1:
+        return toCvCopyImpl(rgb_a, source.header, enc::MONO8, encoding);
+        break;
+      default:
+        return CvImagePtr();
+    }
+  }
+  else {
+    return toCvCopyImpl(rgb_a, source.header, enc::MONO16, encoding);
   }
 }
 

--- a/image_geometry/doc/conf.py
+++ b/image_geometry/doc/conf.py
@@ -22,7 +22,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.pngmath']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.imgmath']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/image_geometry/include/image_geometry/pinhole_camera_model.h
+++ b/image_geometry/include/image_geometry/pinhole_camera_model.h
@@ -125,6 +125,7 @@ public:
    */
   IMAGE_GEOMETRY_PUBLIC
   cv::Point3d projectPixelTo3dRay(const cv::Point2d& uv_rect) const;
+  cv::Point3d projectPixelTo3dRay(const cv::Point2d& uv_rect, const cv::Matx34d& P) const;
 
   /**
    * \brief Rectify a raw camera image.
@@ -145,12 +146,14 @@ public:
    */
   IMAGE_GEOMETRY_PUBLIC
   cv::Point2d rectifyPoint(const cv::Point2d& uv_raw) const;
+  cv::Point2d rectifyPoint(const cv::Point2d& uv_raw, const cv::Matx33d& K, const cv::Matx34d& P) const;
 
   /**
    * \brief Compute the raw image coordinates of a pixel in the rectified image.
    */
   IMAGE_GEOMETRY_PUBLIC
   cv::Point2d unrectifyPoint(const cv::Point2d& uv_rect) const;
+  cv::Point2d unrectifyPoint(const cv::Point2d& uv_rect, const cv::Matx33d& K, const cv::Matx34d& P) const;
 
   /**
    * \brief Compute the rectified ROI best fitting a raw ROI.
@@ -319,6 +322,7 @@ protected:
 
   IMAGE_GEOMETRY_PUBLIC
   void initRectificationMaps() const;
+  void initUnrectificationMaps() const;
 
   friend class StereoCameraModel;
 };

--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -139,7 +139,7 @@ bool PinholeCameraModel::fromCameraInfo(const sensor_msgs::msg::CameraInfo& msg)
   cache_->unrectify_reduced_maps_dirty |= cache_->unrectify_full_maps_dirty;
 
   // As is the rectified ROI
-  cache_->rectified_roi_dirty = reduced_dirty;
+  cache_->rectified_roi_dirty |= reduced_dirty;
 
   // Figure out how to handle the distortion
   if (cam_info_.distortion_model == sensor_msgs::distortion_models::PLUMB_BOB ||
@@ -455,11 +455,12 @@ cv::Rect PinholeCameraModel::rectifyRoi(const cv::Rect& roi_raw) const
   /// @todo Actually implement "best fit" as described by REP 104.
   
   // For now, just unrectify the four corners and take the bounding box.
-  cv::Point2d rect_tl = rectifyPoint(cv::Point2d(roi_raw.x, roi_raw.y));
-  cv::Point2d rect_tr = rectifyPoint(cv::Point2d(roi_raw.x + roi_raw.width, roi_raw.y));
+  // Since ROI is specified in unbinned coordinates (see REP-104), this has to use K_full_ and P_full_.
+  cv::Point2d rect_tl = rectifyPoint(cv::Point2d(roi_raw.x, roi_raw.y), K_full_, P_full_);
+  cv::Point2d rect_tr = rectifyPoint(cv::Point2d(roi_raw.x + roi_raw.width, roi_raw.y), K_full_, P_full_);
   cv::Point2d rect_br = rectifyPoint(cv::Point2d(roi_raw.x + roi_raw.width,
-                                                 roi_raw.y + roi_raw.height));
-  cv::Point2d rect_bl = rectifyPoint(cv::Point2d(roi_raw.x, roi_raw.y + roi_raw.height));
+                                                 roi_raw.y + roi_raw.height), K_full_, P_full_);
+  cv::Point2d rect_bl = rectifyPoint(cv::Point2d(roi_raw.x, roi_raw.y + roi_raw.height), K_full_, P_full_);
 
   cv::Point roi_tl(static_cast<uint32_t>(std::ceil (std::min(rect_tl.x, rect_bl.x))),
                    static_cast<uint32_t>(std::ceil (std::min(rect_tl.y, rect_tr.y))));

--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -4,10 +4,12 @@
 namespace image_geometry {
 
 enum DistortionState { NONE, CALIBRATED, UNKNOWN };
+enum DistortionModel { EQUIDISTANT, PLUMB_BOB_OR_RATIONAL_POLYNOMIAL, UNKNOWN_MODEL };
 
 struct PinholeCameraModel::Cache
 {
   DistortionState distortion_state;
+  DistortionModel distortion_model;
 
   cv::Mat_<double> K_binned, P_binned; // Binning applied, but not cropping
 
@@ -21,7 +23,9 @@ struct PinholeCameraModel::Cache
   mutable cv::Rect rectified_roi;
 
   Cache()
-    : full_maps_dirty(true),
+    : distortion_state(UNKNOWN),
+      distortion_model(UNKNOWN_MODEL),
+      full_maps_dirty(true),
       reduced_maps_dirty(true),
       rectified_roi_dirty(true)
   {
@@ -125,7 +129,8 @@ bool PinholeCameraModel::fromCameraInfo(const sensor_msgs::msg::CameraInfo& msg)
 
   // Figure out how to handle the distortion
   if (cam_info_.distortion_model == sensor_msgs::distortion_models::PLUMB_BOB ||
-      cam_info_.distortion_model == sensor_msgs::distortion_models::RATIONAL_POLYNOMIAL) {
+      cam_info_.distortion_model == sensor_msgs::distortion_models::RATIONAL_POLYNOMIAL ||
+      cam_info_.distortion_model == sensor_msgs::distortion_models::EQUIDISTANT) {
     // If any distortion coefficient is non-zero, then need to apply the distortion
     cache_->distortion_state = NONE;
     for (size_t i = 0; i < cam_info_.d.size(); ++i)
@@ -139,6 +144,17 @@ bool PinholeCameraModel::fromCameraInfo(const sensor_msgs::msg::CameraInfo& msg)
   }
   else
     cache_->distortion_state = UNKNOWN;
+
+  // Get the distortion model, if supported
+  if (cam_info_.distortion_model == sensor_msgs::distortion_models::PLUMB_BOB ||
+      cam_info_.distortion_model == sensor_msgs::distortion_models::RATIONAL_POLYNOMIAL) {
+    cache_->distortion_model = PLUMB_BOB_OR_RATIONAL_POLYNOMIAL;
+  }
+  else if(cam_info_.distortion_model == sensor_msgs::distortion_models::EQUIDISTANT) {
+    cache_->distortion_model = EQUIDISTANT;
+  }
+  else
+    cache_->distortion_model = UNKNOWN_MODEL;
 
   // If necessary, create new K_ and P_ adjusted for binning and ROI
   /// @todo Calculate and use rectified ROI
@@ -338,7 +354,18 @@ cv::Point2d PinholeCameraModel::rectifyPoint(const cv::Point2d& uv_raw) const
   cv::Point2f raw32 = uv_raw, rect32;
   const cv::Mat src_pt(1, 1, CV_32FC2, &raw32.x);
   cv::Mat dst_pt(1, 1, CV_32FC2, &rect32.x);
-  cv::undistortPoints(src_pt, dst_pt, K_, D_, R_, P_);
+
+  switch (cache_->distortion_model) {
+    case PLUMB_BOB_OR_RATIONAL_POLYNOMIAL:
+      cv::undistortPoints(src_pt, dst_pt, K_, D_, R_, P_);
+      break;
+    case EQUIDISTANT:
+      cv::fisheye::undistortPoints(src_pt, dst_pt, K_, D_, R_, P_);
+      break;
+    default:
+      assert(cache_->distortion_model == UNKNOWN_MODEL);
+      throw Exception("Wrong distortion model. Supported models: PLUMB_BOB, RATIONAL_POLYNOMIAL and EQUIDISTANT.");
+  }
   return rect32;
 }
 
@@ -359,7 +386,18 @@ cv::Point2d PinholeCameraModel::unrectifyPoint(const cv::Point2d& uv_rect) const
   cv::Mat r_vec, t_vec = cv::Mat_<double>::zeros(3, 1);
   cv::Rodrigues(R_.t(), r_vec);
   std::vector<cv::Point2d> image_point;
-  cv::projectPoints(std::vector<cv::Point3d>(1, ray), r_vec, t_vec, K_, D_, image_point);
+
+  switch (cache_->distortion_model) {
+    case PLUMB_BOB_OR_RATIONAL_POLYNOMIAL:
+      cv::projectPoints(std::vector<cv::Point3d>(1, ray), r_vec, t_vec, K_, D_, image_point);
+      break;
+    case EQUIDISTANT:
+      cv::fisheye::projectPoints(std::vector<cv::Point3d>(1, ray), image_point, r_vec, t_vec, K_, D_);
+      break;
+    default:
+      assert(cache_->distortion_model == UNKNOWN_MODEL);
+      throw Exception("Wrong distortion model. Supported models: PLUMB_BOB, RATIONAL_POLYNOMIAL and EQUIDISTANT.");
+  }
 
   return image_point[0];
 }
@@ -444,10 +482,21 @@ void PinholeCameraModel::initRectificationMaps() const
         P_binned(1,3) *= scale_y;
       }
     }
-    
-    // Note: m1type=CV_16SC2 to use fast fixed-point maps (see cv::remap)
-    cv::initUndistortRectifyMap(K_binned, D_, R_, P_binned, binned_resolution,
-                                CV_16SC2, cache_->full_map1, cache_->full_map2);
+
+    switch (cache_->distortion_model) {
+      case PLUMB_BOB_OR_RATIONAL_POLYNOMIAL:
+        // Note: m1type=CV_16SC2 to use fast fixed-point maps (see cv::remap)
+        cv::initUndistortRectifyMap(K_binned, D_, R_, P_binned, binned_resolution,
+                                    CV_16SC2, cache_->full_map1, cache_->full_map2);
+        break;
+      case EQUIDISTANT:
+        cv::fisheye::initUndistortRectifyMap(K_binned,D_, R_, P_binned, binned_resolution,
+                                             CV_16SC2, cache_->full_map1, cache_->full_map2);
+        break;
+      default:
+        assert(cache_->distortion_model == UNKNOWN_MODEL);
+        throw Exception("Wrong distortion model. Supported models: PLUMB_BOB, RATIONAL_POLYNOMIAL and EQUIDISTANT.");
+    }
     cache_->full_maps_dirty = false;
   }
 

--- a/image_geometry/test/CMakeLists.txt
+++ b/image_geometry/test/CMakeLists.txt
@@ -6,3 +6,6 @@ find_package(ament_cmake_gtest REQUIRED)
 
 ament_add_gtest(${PROJECT_NAME}-utest utest.cpp)
 target_link_libraries(${PROJECT_NAME}-utest ${PROJECT_NAME})
+
+ament_add_gtest(${PROJECT_NAME}-utest-equi utest_equi.cpp)
+target_link_libraries(${PROJECT_NAME}-utest-equi ${PROJECT_NAME})

--- a/image_geometry/test/utest.cpp
+++ b/image_geometry/test/utest.cpp
@@ -4,7 +4,7 @@
 
 /// @todo Tests with simple values (R = identity, D = 0, P = K or simple scaling)
 /// @todo Test projection functions for right stereo values, P(:,3) != 0
-/// @todo Tests for [un]rectifyImage
+/// @todo Tests for rectifyImage
 /// @todo Tests using ROI, needs support from PinholeCameraModel
 /// @todo Tests for StereoCameraModel
 
@@ -249,6 +249,124 @@ TEST_F(PinholeTest, rectifyIfCalibrated)
 
   // restore original distortion
   model_.fromCameraInfo(cam_info_);
+}
+
+void testUnrectifyImage(const sensor_msgs::msg::CameraInfo& cam_info, const image_geometry::PinholeCameraModel& model)
+{
+  // test for unrectifyImage: call unrectifyImage, call unrectifyPoint in a loop, compare
+
+  // prepare rectified_image
+  cv::Mat rectified_image(model.fullResolution(), CV_8UC3, cv::Scalar(0, 0, 0));
+
+  // draw a grid
+  const cv::Scalar color = cv::Scalar(255, 255, 255);
+  const int thickness = 7;
+  const int type = 8;
+  for (int y = 0; y <= rectified_image.rows; y += rectified_image.rows / 10)
+  {
+    cv::line(rectified_image,
+             cv::Point(0, y), cv::Point(cam_info.width, y),
+             color, type, thickness);
+  }
+  for (int x = 0; x <= rectified_image.cols; x += rectified_image.cols / 10)
+  {
+    cv::line(rectified_image,
+             cv::Point(x, 0), cv::Point(x, cam_info.height),
+             color, type, thickness);
+  }
+
+  // restrict rectified_image to ROI and resize to new binning
+  rectified_image = rectified_image(model.rawRoi());
+  cv::resize(rectified_image, rectified_image, cv::Size(), 1.0 / model.binningX(), 1.0 / model.binningY(),
+             cv::INTER_NEAREST);
+
+  // unrectify image in one go using unrectifyImage
+  cv::Mat distorted_image;
+  // Just making this number up, maybe ought to be larger
+  // since a completely different image would be on the order of
+  // width * height * 255 = 78e6
+  const double diff_threshold = 10000.0;
+  double error;
+
+  // Test that unrectified image is sufficiently different
+  // using default distortion
+  model.unrectifyImage(rectified_image, distorted_image);
+  error = cv::norm(rectified_image, distorted_image, cv::NORM_L1);
+  // Just making this number up, maybe ought to be larger
+  EXPECT_GT(error, diff_threshold);
+
+  // unrectify image pixel by pixel using unrectifyPoint
+  assert(rectified_image.type() == CV_8UC3);  // need this for at<cv::Vec3b> to be correct
+  cv::Mat distorted_image_by_pixel = cv::Mat::zeros(rectified_image.size(), rectified_image.type());
+  cv::Mat mask = cv::Mat::zeros(rectified_image.size(), CV_8UC1);
+  for (int y = 0; y < rectified_image.rows; y++)
+  {
+    for (int x = 0; x < rectified_image.cols; x++)
+    {
+      cv::Point2i uv_rect(x, y), uv_raw;
+
+      uv_raw = model.unrectifyPoint(uv_rect);
+
+      if (0 <= uv_raw.x && uv_raw.x < distorted_image_by_pixel.cols && 0 <= uv_raw.y
+          && uv_raw.y < distorted_image_by_pixel.rows)
+      {
+        distorted_image_by_pixel.at<cv::Vec3b>(uv_raw) = rectified_image.at<cv::Vec3b>(uv_rect);
+        mask.at<uchar>(uv_raw) = 255;
+        // Test that both methods produce similar values at the pixels that unrectifyPoint hits; don't test for all
+        // other pixels (the images will differ there, because unrectifyPoint doesn't interpolate missing pixels).
+        // Also don't check for absolute equality, but allow a color difference of up to 200. This still catches
+        // complete misses (color difference would be 255) while allowing for interpolation at the grid borders.
+        EXPECT_LT(distorted_image.at<cv::Vec3b>(uv_raw)[0] - distorted_image_by_pixel.at<cv::Vec3b>(uv_raw)[0], 200);
+      }
+    }
+  }
+
+  // Test that absolute error (due to interpolation) is less than 6% of the maximum possible error
+  error = cv::norm(distorted_image, distorted_image_by_pixel, cv::NORM_L1, mask);
+  EXPECT_LT(error / (distorted_image.size[0] * distorted_image.size[1] * 255), 0.06);
+
+  // Test that unrectifyPoint hits more than 50% of the output image
+  EXPECT_GT((double) cv::countNonZero(mask) / (distorted_image.size[0] * distorted_image.size[1]), 0.5);
+};
+
+TEST_F(PinholeTest, unrectifyImage)
+{
+  testUnrectifyImage(cam_info_, model_);
+}
+
+TEST_F(PinholeTest, unrectifyImageWithBinning)
+{
+  cam_info_.binning_x = 2;
+  cam_info_.binning_y = 2;
+  model_.fromCameraInfo(cam_info_);
+
+  testUnrectifyImage(cam_info_, model_);
+}
+
+TEST_F(PinholeTest, unrectifyImageWithRoi)
+{
+  cam_info_.roi.x_offset = 100;
+  cam_info_.roi.y_offset = 50;
+  cam_info_.roi.width = 400;
+  cam_info_.roi.height = 300;
+  cam_info_.roi.do_rectify = true;
+  model_.fromCameraInfo(cam_info_);
+
+  testUnrectifyImage(cam_info_, model_);
+}
+
+TEST_F(PinholeTest, unrectifyImageWithBinningAndRoi)
+{
+  cam_info_.binning_x = 2;
+  cam_info_.binning_y = 2;
+  cam_info_.roi.x_offset = 100;
+  cam_info_.roi.y_offset = 50;
+  cam_info_.roi.width = 400;
+  cam_info_.roi.height = 300;
+  cam_info_.roi.do_rectify = true;
+  model_.fromCameraInfo(cam_info_);
+
+  testUnrectifyImage(cam_info_, model_);
 }
 
 int main(int argc, char** argv)

--- a/image_geometry/test/utest.cpp
+++ b/image_geometry/test/utest.cpp
@@ -246,9 +246,6 @@ TEST_F(PinholeTest, rectifyIfCalibrated)
   model_.rectifyImage(distorted_image, rectified_image);
   error = cv::norm(distorted_image, rectified_image, cv::NORM_L1);
   EXPECT_EQ(error, 0);
-
-  // restore original distortion
-  model_.fromCameraInfo(cam_info_);
 }
 
 void testUnrectifyImage(const sensor_msgs::msg::CameraInfo& cam_info, const image_geometry::PinholeCameraModel& model)
@@ -367,6 +364,96 @@ TEST_F(PinholeTest, unrectifyImageWithBinningAndRoi)
   model_.fromCameraInfo(cam_info_);
 
   testUnrectifyImage(cam_info_, model_);
+}
+
+TEST_F(PinholeTest, rectifiedRoiSize) {
+
+  cv::Rect rectified_roi = model_.rectifiedRoi();
+  cv::Size reduced_resolution = model_.reducedResolution();
+  EXPECT_EQ(0, rectified_roi.x);
+  EXPECT_EQ(0, rectified_roi.y);
+  EXPECT_EQ(640, rectified_roi.width);
+  EXPECT_EQ(480, rectified_roi.height);
+  EXPECT_EQ(640, reduced_resolution.width);
+  EXPECT_EQ(480, reduced_resolution.height);
+
+  cam_info_.binning_x = 2;
+  cam_info_.binning_y = 2;
+  model_.fromCameraInfo(cam_info_);
+  rectified_roi = model_.rectifiedRoi();
+  reduced_resolution = model_.reducedResolution();
+  EXPECT_EQ(0, rectified_roi.x);
+  EXPECT_EQ(0, rectified_roi.y);
+  EXPECT_EQ(640, rectified_roi.width);
+  EXPECT_EQ(480, rectified_roi.height);
+  EXPECT_EQ(320, reduced_resolution.width);
+  EXPECT_EQ(240, reduced_resolution.height);
+
+  cam_info_.binning_x = 1;
+  cam_info_.binning_y = 1;
+  cam_info_.roi.x_offset = 100;
+  cam_info_.roi.y_offset = 50;
+  cam_info_.roi.width = 400;
+  cam_info_.roi.height = 300;
+  cam_info_.roi.do_rectify = true;
+  model_.fromCameraInfo(cam_info_);
+  rectified_roi = model_.rectifiedRoi();
+  reduced_resolution = model_.reducedResolution();
+  EXPECT_EQ(137, rectified_roi.x);
+  EXPECT_EQ(82, rectified_roi.y);
+  EXPECT_EQ(321, rectified_roi.width);
+  EXPECT_EQ(242, rectified_roi.height);
+  EXPECT_EQ(321, reduced_resolution.width);
+  EXPECT_EQ(242, reduced_resolution.height);
+
+  cam_info_.binning_x = 2;
+  cam_info_.binning_y = 2;
+  cam_info_.roi.x_offset = 100;
+  cam_info_.roi.y_offset = 50;
+  cam_info_.roi.width = 400;
+  cam_info_.roi.height = 300;
+  cam_info_.roi.do_rectify = true;
+  model_.fromCameraInfo(cam_info_);
+  rectified_roi = model_.rectifiedRoi();
+  reduced_resolution = model_.reducedResolution();
+  EXPECT_EQ(137, rectified_roi.x);
+  EXPECT_EQ(82, rectified_roi.y);
+  EXPECT_EQ(321, rectified_roi.width);
+  EXPECT_EQ(242, rectified_roi.height);
+  EXPECT_EQ(160, reduced_resolution.width);
+  EXPECT_EQ(121, reduced_resolution.height);
+}
+
+TEST_F(PinholeTest, rectifiedRoiCaching)
+{
+  // Test that the following sequence works correctly:
+  // 1. fromCameraInfo is called with ROI A.  | rectified_roi_dirty = true
+  // (already happened in SetUp())
+
+  // 2. rectifiedRoi is called                | rectified_roi_dirty = false
+  cv::Rect actual_roi_a = model_.rectifiedRoi();
+  cv::Rect expected_roi_a(0, 0, 640, 480);
+  EXPECT_EQ(expected_roi_a, actual_roi_a);
+
+  // 3. fromCameraInfo is called with ROI B.  | rectified_roi_dirty = true
+  cam_info_.roi.x_offset = 100;
+  cam_info_.roi.y_offset = 50;
+  cam_info_.roi.width = 400;
+  cam_info_.roi.height = 300;
+  cam_info_.roi.do_rectify = true;
+  model_.fromCameraInfo(cam_info_);
+
+  // 4. fromCameraInfo is called again with ROI B.  | rectified_roi_dirty should still be true!
+  model_.fromCameraInfo(cam_info_);
+
+  // 5. rectifiedRoi is called
+  // There was a bug before where rectified_roi_dirty was incorrectly set to `false` by step 4.
+  // If rectifiedRoi was called again, the cached rectified_roi for
+  // ROI A was returned, but it should be recalculated based on ROI B.
+  // This test checks that this behavior is correct.
+  cv::Rect actual_roi_b = model_.rectifiedRoi();
+  cv::Rect expected_roi_b(137, 82, 321, 242);
+  EXPECT_EQ(expected_roi_b, actual_roi_b);
 }
 
 int main(int argc, char** argv)

--- a/image_geometry/test/utest_equi.cpp
+++ b/image_geometry/test/utest_equi.cpp
@@ -1,0 +1,257 @@
+#include "image_geometry/pinhole_camera_model.h"
+#include <sensor_msgs/distortion_models.hpp>
+#include <gtest/gtest.h>
+
+/// @todo Tests with simple values (R = identity, D = 0, P = K or simple scaling)
+/// @todo Test projection functions for right stereo values, P(:,3) != 0
+/// @todo Tests for [un]rectifyImage
+/// @todo Tests using ROI, needs support from PinholeCameraModel
+/// @todo Tests for StereoCameraModel
+
+class EquidistantTest : public testing::Test
+{
+protected:
+  virtual void SetUp()
+  {
+    /// @todo Just load these from file
+    // These parameters are taken from a real camera calibration
+    double D[] = {-0.08857683871674071, 0.0708113094372378, -0.09127623055964429, 0.04006922269778478};
+    double K[] = {403.603063319358,               0.0, 306.15842863283063,
+                               0.0, 403.7028851121003, 261.09715697592696,
+                               0.0,               0.0,                1.0};
+    double R[] = {0.999963944103842, -0.008484152966323483, 0.00036005656766869323,
+                  0.008484153516269438, 0.9999640089218772, 0.0,
+                  -0.0003600436088446379, 3.0547751946422504e-06, 0.999999935179632};
+    double P[] = {347.2569964503485, 0.0, 350.5, 0.0,
+                  0.0, 347.2569964503485, 256.0, 0.0,
+                  0.0, 0.0, 1.0, 0.0};
+
+    cam_info_.header.frame_id = "tf_frame";
+    cam_info_.height = 512;
+    cam_info_.width  = 640;
+    // No ROI
+    cam_info_.d.resize(4);
+    std::copy(D, D+4, cam_info_.d.begin());
+    std::copy(K, K+9, cam_info_.k.begin());
+    std::copy(R, R+9, cam_info_.r.begin());
+    std::copy(P, P+12, cam_info_.p.begin());
+    cam_info_.distortion_model = sensor_msgs::distortion_models::EQUIDISTANT;
+
+    model_.fromCameraInfo(cam_info_);
+  }
+
+  sensor_msgs::msg::CameraInfo cam_info_;
+  image_geometry::PinholeCameraModel model_;
+};
+
+TEST_F(EquidistantTest, accessorsCorrect)
+{
+  EXPECT_STREQ("tf_frame", model_.tfFrame().c_str());
+  EXPECT_EQ(cam_info_.p[0], model_.fx());
+  EXPECT_EQ(cam_info_.p[5], model_.fy());
+  EXPECT_EQ(cam_info_.p[2], model_.cx());
+  EXPECT_EQ(cam_info_.p[6], model_.cy());
+}
+
+TEST_F(EquidistantTest, projectPoint)
+{
+  // Spot test an arbitrary point.
+  {
+    cv::Point2d uv(100, 100);
+    cv::Point3d xyz =  model_.projectPixelTo3dRay(uv);
+    EXPECT_NEAR(-0.72136775518018115, xyz.x, 1e-8);
+    EXPECT_NEAR(-0.449235009214005, xyz.y, 1e-8);
+    EXPECT_DOUBLE_EQ(1.0, xyz.z);
+  }
+
+  // Principal point should project straight out.
+  {
+    cv::Point2d uv(model_.cx(), model_.cy());
+    cv::Point3d xyz = model_.projectPixelTo3dRay(uv);
+    EXPECT_DOUBLE_EQ(0.0, xyz.x);
+    EXPECT_DOUBLE_EQ(0.0, xyz.y);
+    EXPECT_DOUBLE_EQ(1.0, xyz.z);
+  }
+
+  // Check projecting to 3d and back over entire image is accurate.
+  const size_t step = 10;
+  for (size_t row = 0; row <= cam_info_.height; row += step) {
+    for (size_t col = 0; col <= cam_info_.width; col += step) {
+      cv::Point2d uv(row, col), uv_back;
+      cv::Point3d xyz = model_.projectPixelTo3dRay(uv);
+      uv_back = model_.project3dToPixel(xyz);
+      // Measured max error at 1.13687e-13
+      EXPECT_NEAR(uv.x, uv_back.x, 1.14e-13) << "at (" << row << ", " << col << ")";
+      EXPECT_NEAR(uv.y, uv_back.y, 1.14e-13) << "at (" << row << ", " << col << ")";
+    }
+  }
+}
+
+TEST_F(EquidistantTest, rectifyPoint)
+{
+  // Spot test an arbitrary point.
+  {
+    cv::Point2d uv_raw(100, 100), uv_rect;
+    uv_rect = model_.rectifyPoint(uv_raw);
+    EXPECT_DOUBLE_EQ(135.45747375488281, uv_rect.x);
+    EXPECT_DOUBLE_EQ(84.945091247558594, uv_rect.y);
+  }
+
+  /// @todo Need R = identity for the principal point tests.
+#if 0
+  // Test rectifyPoint takes (c'x, c'y) [from K] -> (cx, cy) [from P].
+  double cxp = model_.intrinsicMatrix()(0,2), cyp = model_.intrinsicMatrix()(1,2);
+  {
+    cv::Point2d uv_raw(cxp, cyp), uv_rect;
+    model_.rectifyPoint(uv_raw, uv_rect);
+    EXPECT_NEAR(uv_rect.x, model_.cx(), 1e-4);
+    EXPECT_NEAR(uv_rect.y, model_.cy(), 1e-4);
+  }
+
+  // Test unrectifyPoint takes (cx, cy) [from P] -> (c'x, c'y) [from K].
+  {
+    cv::Point2d uv_rect(model_.cx(), model_.cy()), uv_raw;
+    model_.unrectifyPoint(uv_rect, uv_raw);
+    EXPECT_NEAR(uv_raw.x, cxp, 1e-4);
+    EXPECT_NEAR(uv_raw.y, cyp, 1e-4);
+  }
+#endif
+
+  // Check rectifying then unrectifying is accurate.
+  const size_t step = 5;
+  for (size_t row = 0; row <= cam_info_.height; row += step) {
+    for (size_t col = 0; col <= cam_info_.width; col += step) {
+      cv::Point2d uv_raw(row, col), uv_rect, uv_unrect;
+      uv_rect = model_.rectifyPoint(uv_raw);
+      uv_unrect = model_.unrectifyPoint(uv_rect);
+      EXPECT_NEAR(uv_raw.x, uv_unrect.x, 0.01);
+      EXPECT_NEAR(uv_raw.y, uv_unrect.y, 0.01);
+    }
+  }
+}
+
+TEST_F(EquidistantTest, getDeltas)
+{
+  double u = 100.0, v = 200.0, du = 17.0, dv = 23.0, Z = 2.0;
+  cv::Point2d uv0(u, v), uv1(u + du, v + dv);
+  cv::Point3d xyz0, xyz1;
+  xyz0 = model_.projectPixelTo3dRay(uv0);
+  xyz0 *= (Z / xyz0.z);
+  xyz1 = model_.projectPixelTo3dRay(uv1);
+  xyz1 *= (Z / xyz1.z);
+
+  EXPECT_NEAR(model_.getDeltaU(xyz1.x - xyz0.x, Z), du, 1e-4);
+  EXPECT_NEAR(model_.getDeltaV(xyz1.y - xyz0.y, Z), dv, 1e-4);
+  EXPECT_NEAR(model_.getDeltaX(du, Z), xyz1.x - xyz0.x, 1e-4);
+  EXPECT_NEAR(model_.getDeltaY(dv, Z), xyz1.y - xyz0.y, 1e-4);
+}
+
+TEST_F(EquidistantTest, initialization)
+{
+
+    sensor_msgs::msg::CameraInfo info;
+    image_geometry::PinholeCameraModel camera;
+
+    camera.fromCameraInfo(info);
+
+    EXPECT_EQ(camera.initialized(), 1);
+    EXPECT_EQ(camera.projectionMatrix().rows, 3);
+    EXPECT_EQ(camera.projectionMatrix().cols, 4);
+}
+
+TEST_F(EquidistantTest, rectifyIfCalibrated)
+{
+  /// @todo use forward distortion for a better test
+  // Ideally this test would have two images stored on disk
+  // one which is distorted and the other which is rectified,
+  // and then rectification would take place here and the output
+  // image compared to the one on disk (which would mean if
+  // the distortion coefficients above can't change once paired with
+  // an image).
+
+  // Later could incorporate distort code
+  // (https://github.com/lucasw/vimjay/blob/master/src/standalone/distort_image.cpp)
+  // to take any image distort it, then undistort with rectifyImage,
+  // and given the distortion coefficients are consistent the input image
+  // and final output image should be mostly the same (though some
+  // interpolation error
+  // creeps in), except for outside a masked region where information was lost.
+  // The masked region can be generated with a pure white image that
+  // goes through the same process (if it comes out completely black
+  // then the distortion parameters are problematic).
+
+  // For now generate an image and pass the test simply if
+  // the rectified image does not match the distorted image.
+  // Then zero out the first distortion coefficient and run
+  // the test again.
+  // Then zero out all the distortion coefficients and test
+  // that the output image is the same as the input.
+  cv::Mat distorted_image(cv::Size(cam_info_.width, cam_info_.height), CV_8UC3, cv::Scalar(0, 0, 0));
+
+  // draw a grid
+  const cv::Scalar color = cv::Scalar(255, 255, 255);
+  // draw the lines thick so the proportion of error due to
+  // interpolation is reduced
+  const int thickness = 7;
+  const int type = 8;
+  for (size_t y = 0; y <= cam_info_.height; y += cam_info_.height/10)
+  {
+    cv::line(distorted_image,
+             cv::Point(0, y), cv::Point(cam_info_.width, y),
+             color, type, thickness);
+  }
+  for (size_t x = 0; x <= cam_info_.width; x += cam_info_.width/10)
+  {
+    // draw the lines thick so the prorportion of interpolation error is reduced
+    cv::line(distorted_image,
+             cv::Point(x, 0), cv::Point(x, cam_info_.height),
+             color, type, thickness);
+  }
+
+  cv::Mat rectified_image;
+  // Just making this number up, maybe ought to be larger
+  // since a completely different image would be on the order of
+  // width * height * 255 = 78e6
+  const double diff_threshold = 10000.0;
+  double error;
+
+  // Test that rectified image is sufficiently different
+  // using default distortion
+  model_.rectifyImage(distorted_image, rectified_image);
+  error = cv::norm(distorted_image, rectified_image, cv::NORM_L1);
+  // Just making this number up, maybe ought to be larger
+  EXPECT_GT(error, diff_threshold);
+
+  // Test that rectified image is sufficiently different
+  // using default distortion but with first element zeroed
+  // out.
+  sensor_msgs::msg::CameraInfo cam_info_2 = cam_info_;
+  cam_info_2.d[0] = 0.0;
+  model_.fromCameraInfo(cam_info_2);
+  model_.rectifyImage(distorted_image, rectified_image);
+  error = cv::norm(distorted_image, rectified_image, cv::NORM_L1);
+  EXPECT_GT(error, diff_threshold);
+
+  // Test that rectified image is the same using zero distortion
+  cam_info_2.d.assign(cam_info_2.d.size(), 0);
+  model_.fromCameraInfo(cam_info_2);
+  model_.rectifyImage(distorted_image, rectified_image);
+  error = cv::norm(distorted_image, rectified_image, cv::NORM_L1);
+  EXPECT_EQ(error, 0);
+
+  // Test that rectified image is the same using empty distortion
+  cam_info_2.d.clear();
+  model_.fromCameraInfo(cam_info_2);
+  model_.rectifyImage(distorted_image, rectified_image);
+  error = cv::norm(distorted_image, rectified_image, cv::NORM_L1);
+  EXPECT_EQ(error, 0);
+
+  // restore original distortion
+  model_.fromCameraInfo(cam_info_);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR forward-ports all unmerged pull requests from noetic to ROS2:

* Add header arg to cv2_to_imgmsg (#326)
* prevent conversion of single channel 16bit integer images to/from colour (#412)
* substituted missing sphinx extension (#417)
* Fix rectifyRoi when used with binning and/or ROI (#378)
* Implement unrectifyImage() (#359)
* Add equidistant distortion model (#358)

Please do **not** squash this PR, otherwise all PRs will be squashed into a single commit, which would be really bad for readability of the Git history.