### PR TITLE
Use Boost::pythonXY target

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -12,28 +12,22 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra)
 endif()
 
-if(NOT ANDROID)
-  find_package(PythonLibs)
-  if(PYTHONLIBS_VERSION_STRING VERSION_LESS 3)
-    find_package(Boost REQUIRED python)
-  else()
-    find_package(Boost QUIET)
-    if(Boost_VERSION LESS 106500)
-      find_package(Boost REQUIRED python)
-    else()
-      # This is a bit of a hack to suppress a warning
-      #   No header defined for python3; skipping header check
-      # Which should only affect Boost versions < 1.67
-      # Resolution for newer versions:
-      #  https://gitlab.kitware.com/cmake/cmake/issues/16391
-      if (Boost_VERSION LESS 106700)
-        set(_Boost_PYTHON3_HEADERS "boost/python.hpp")
-      endif()
-      find_package(Boost COMPONENTS python3 REQUIRED)
-    endif()
-  endif()
+if(ANDROID)
+  find_package(Boost REQUIRED)
+  set(boost_python_target "")
 else()
-  find_package(Boost REQUIRED COMPONENTS python)
+  find_package(Boost QUIET)
+  if(Boost_VERSION_STRING VERSION_LESS "1.67")
+    # This is a bit of a hack to suppress a warning
+    #   No header defined for python3; skipping header check
+    # Which should only affect Boost versions < 1.67
+    # Resolution for newer versions:
+    #  https://gitlab.kitware.com/cmake/cmake/issues/16391
+    set(_Boost_PYTHON3_HEADERS "boost/python.hpp")
+  endif()
+  find_package(Python3 REQUIRED COMPONENTS Development NumPy)
+  find_package(Boost REQUIRED COMPONENTS python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR})
+  set(boost_python_target "Boost::python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
 endif()
 
 find_package(sensor_msgs REQUIRED)

--- a/cv_bridge/src/CMakeLists.txt
+++ b/cv_bridge/src/CMakeLists.txt
@@ -25,12 +25,10 @@ install(FILES
   DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME})
 
 if(NOT ANDROID)
-  find_package(Python3 REQUIRED COMPONENTS Development NumPy)
-
   Python3_add_library(${PROJECT_NAME}_boost MODULE module.cpp module_opencv3.cpp)
   target_link_libraries(${PROJECT_NAME}_boost PRIVATE
     ${PROJECT_NAME}
-    Boost::python
+    ${boost_python_target}
     Python3::NumPy)
   target_compile_definitions(${PROJECT_NAME}_boost PRIVATE PYTHON3)
 


### PR DESCRIPTION
This PR links against the `Boost::pythonXY` target since that's the portable CMake target naming.

This should fix the build failure on RHEL8 https://build.ros2.org/view/Rbin_rhel_el864/job/Rbin_rhel_el864__cv_bridge__rhel_8_x86_64__binary/56/consoleText



```
DEBUG: CMake Error at /usr/share/cmake/Modules/FindPython/Support.cmake:3315 (add_library):
DEBUG:   Target "cv_bridge_boost" links to target "Boost::python" but the target was
DEBUG:   not found.  Perhaps a find_package() call is missing for an IMPORTED
DEBUG:   target, or an ALIAS target is missing?
```

#390 and #344 are doing very similar things, and I think this PR replaces them. I used feedback from both of those in this one. (@flynneva and @floesche FYI)