### PR TITLE
Use Boost::python3 if Boost < 1.67

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -24,10 +24,13 @@ else()
     # Resolution for newer versions:
     #  https://gitlab.kitware.com/cmake/cmake/issues/16391
     set(_Boost_PYTHON3_HEADERS "boost/python.hpp")
+    find_package(Boost REQUIRED COMPONENTS python3)
+    set(boost_python_target "Boost::python3")
+  else()
+    find_package(Python3 REQUIRED COMPONENTS Development NumPy)
+    find_package(Boost REQUIRED COMPONENTS python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR})
+    set(boost_python_target "Boost::python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
   endif()
-  find_package(Python3 REQUIRED COMPONENTS Development NumPy)
-  find_package(Boost REQUIRED COMPONENTS python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR})
-  set(boost_python_target "Boost::python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
 endif()
 
 find_package(sensor_msgs REQUIRED)


### PR DESCRIPTION
I made a mistake in #421 - when boost is less than 1.67 use the `Boost::python3` target instead of the `Boost::pythonXY` target.

This time in addition to testing this PR by building and testing `cv_bridge` on Focal locally, I also ran this CMake code in a stub project on almalinux 8 to make sure it works with boost 1.66