### PR TITLE
[cv_bridge][ROS 2] Add missing dependency on rcpputils

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -33,6 +33,7 @@ else()
   endif()
 endif()
 
+find_package(rcpputils REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
 find_package(OpenCV 4 QUIET

--- a/cv_bridge/package.xml
+++ b/cv_bridge/package.xml
@@ -21,6 +21,7 @@
 
   <depend>libopencv-dev</depend>
   <depend>python3-numpy</depend>
+  <depend>rcpputils</depend>
   <depend>sensor_msgs</depend>
 
   <exec_depend>ament_index_python</exec_depend>

--- a/cv_bridge/src/CMakeLists.txt
+++ b/cv_bridge/src/CMakeLists.txt
@@ -12,7 +12,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   opencv_imgproc
   opencv_imgcodecs)
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  Boost::headers)
+  Boost::headers
+  rcpputils::rcpputils)
 
 install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib


### PR DESCRIPTION
It's used here:

https://github.com/ros-perception/vision_opencv/blob/cdb3f24d848dd9301cb294c3e228b4599876139a/cv_bridge/src/cv_bridge.cpp#L43