### PR TITLE
add fovX and fovY functions in python, cpp

### DIFF
--- a/image_geometry/include/image_geometry/pinhole_camera_model.h
+++ b/image_geometry/include/image_geometry/pinhole_camera_model.h
@@ -6,6 +6,7 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <stdexcept>
 #include <string>
+#include <math.h>
 #include "exports.h"
 
 namespace image_geometry {
@@ -209,6 +210,16 @@ public:
   double Ty() const;
 
   /**
+   * \brief Returns the horizontal field of view in radians.
+   */
+  double fovX() const;
+
+  /**
+   * \brief Returns the vertical field of view in radians.
+   */
+  double fovY() const;
+
+  /**
    * \brief Returns the number of columns in each bin.
    */
   uint32_t binningX() const;
@@ -217,7 +228,7 @@ public:
    * \brief Returns the number of rows in each bin.
    */
   uint32_t binningY() const;
-  
+
   /**
    * \brief Compute delta u, given Z and delta X in Cartesian space.
    *
@@ -314,6 +325,13 @@ inline double PinholeCameraModel::cx() const { return P_(0,2); }
 inline double PinholeCameraModel::cy() const { return P_(1,2); }
 inline double PinholeCameraModel::Tx() const { return P_(0,3); }
 inline double PinholeCameraModel::Ty() const { return P_(1,3); }
+
+inline double PinholeCameraModel::fovX() const {
+        return 2 * atan(rawRoi().width / (2 * fx()));
+}
+inline double PinholeCameraModel::fovY() const {
+        return 2 * atan(rawRoi().height / (2 * fy()));
+}
 
 inline uint32_t PinholeCameraModel::binningX() const { return cam_info_.binning_x; }
 inline uint32_t PinholeCameraModel::binningY() const { return cam_info_.binning_y; }

--- a/image_geometry/src/pinhole_camera_model.cpp
+++ b/image_geometry/src/pinhole_camera_model.cpp
@@ -284,7 +284,7 @@ cv::Rect PinholeCameraModel::rawRoi() const
 cv::Rect PinholeCameraModel::rectifiedRoi() const
 {
   assert( initialized() );
-  
+
   if (cache_->rectified_roi_dirty)
   {
     if (!cam_info_.roi.do_rectify)
@@ -458,7 +458,7 @@ cv::Rect PinholeCameraModel::rectifyRoi(const cv::Rect& roi_raw) const
   assert( initialized() );
 
   /// @todo Actually implement "best fit" as described by REP 104.
-  
+
   // For now, just unrectify the four corners and take the bounding box.
   // Since ROI is specified in unbinned coordinates (see REP-104), this has to use K_full_ and P_full_.
   cv::Point2d rect_tl = rectifyPoint(cv::Point2d(roi_raw.x, roi_raw.y), K_full_, P_full_);
@@ -480,7 +480,7 @@ cv::Rect PinholeCameraModel::unrectifyRoi(const cv::Rect& roi_rect) const
   assert( initialized() );
 
   /// @todo Actually implement "best fit" as described by REP 104.
-  
+
   // For now, just unrectify the four corners and take the bounding box.
   cv::Point2d raw_tl = unrectifyPoint(cv::Point2d(roi_rect.x, roi_rect.y));
   cv::Point2d raw_tr = unrectifyPoint(cv::Point2d(roi_rect.x + roi_rect.width, roi_rect.y));
@@ -500,7 +500,7 @@ void PinholeCameraModel::initRectificationMaps() const
 {
   /// @todo For large binning settings, can drop extra rows/cols at bottom/right boundary.
   /// Make sure we're handling that 100% correctly.
-  
+
   if (cache_->full_maps_dirty) {
     // Create the full-size map at the binned resolution
     /// @todo Should binned resolution, K, P be part of public API?


### PR DESCRIPTION
Simple functions to provide the field of view for a device given camera intrinsics. Tested on RealSense D435 and seems to work for both stereo and raw image feeds in Python, providing values that are in-line with the documentation. Also ported over to C++.

There's also some minor typo fixes.