### PR TITLE
python3-opencv should be a more general dependency

### DIFF
--- a/cv_bridge/package.xml
+++ b/cv_bridge/package.xml
@@ -23,6 +23,7 @@
   <depend>python3-numpy</depend>
   <depend>rcpputils</depend>
   <depend>sensor_msgs</depend>
+  <depend>python3-opencv</depend>
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>libboost-python</exec_depend>
@@ -31,7 +32,6 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>python3-opencv</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
cv2 is being used as a dependency at run time:

https://github.com/ros-perception/vision_opencv/blob/0b69de38953f21090ac62bc90eb700e8bc98a023/cv_bridge/python/cv_bridge/core.py#L71

and hence should be listed not only as a test dependency, but as a general dependency, like python3-numpy is a couple of lines above the change in this PR.