### PR TITLE
Fix 16U encoding type

### DIFF
--- a/cv_bridge/src/cv_bridge.cpp
+++ b/cv_bridge/src/cv_bridge.cpp
@@ -682,9 +682,9 @@ CvImageConstPtr cvtColorForDisplay(const CvImageConstPtr& source,
   else if (source->encoding == "CV_8UC4")
     source_typed->encoding = enc::BGRA8;
   else if (source->encoding == "CV_16UC3")
-    source_typed->encoding = enc::BGR8;
+    source_typed->encoding = enc::BGR16;
   else if (source->encoding == "CV_16UC4")
-    source_typed->encoding = enc::BGRA8;
+    source_typed->encoding = enc::BGRA16;
 
   // If no conversion is needed, don't convert
   if (source_typed->encoding == encoding)


### PR DESCRIPTION
Hello, 
I have noticed that "CV_16UC3" is converted to "BGR8" and "CV_16UC4" to "BGRA8" in some parts of the cv_bridge code. 
this PR fixes it. 