### PR TITLE
Link tests against target, and separate tests

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -61,12 +61,6 @@ endif()
 
 add_subdirectory(src)
 
-# cv_bridge_lib_dir is passed as APPEND_LIBRARY_DIRS for each ament_add_gtest call so
-# the project library that they link against is on the library path.
-# This is especially important on Windows.
-# This is overwritten each loop, but which one it points to doesn't really matter.
-set(cv_bridge_lib_dir "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
-
 if(BUILD_TESTING)
   add_subdirectory(test)
 endif()

--- a/cv_bridge/test/CMakeLists.txt
+++ b/cv_bridge/test/CMakeLists.txt
@@ -13,18 +13,20 @@ endif()
 
 # enable cv_bridge C++ tests
 find_package(ament_cmake_gtest REQUIRED)
-ament_add_gtest(${PROJECT_NAME}-utest
-  test_endian.cpp
-  test_compression.cpp
-  utest.cpp utest2.cpp
-  test_rgb_colors.cpp
-  APPEND_LIBRARY_DIRS "${cv_bridge_lib_dir}")
-target_link_libraries(${PROJECT_NAME}-utest
-  ${PROJECT_NAME}
-  Boost::headers
-  opencv_core
-  opencv_imgcodecs
-  ${sensor_msgs_TARGETS})
+ament_add_gtest(test_compression test_compression.cpp)
+target_link_libraries(test_compression ${PROJECT_NAME})
+
+ament_add_gtest(test_endian test_endian.cpp)
+target_link_libraries(test_endian ${PROJECT_NAME})
+
+ament_add_gtest(test_rgb_colors test_rgb_colors.cpp)
+target_link_libraries(test_rgb_colors ${PROJECT_NAME})
+
+ament_add_gtest(utest utest.cpp)
+target_link_libraries(utest ${PROJECT_NAME})
+
+ament_add_gtest(utest2 utest2.cpp)
+target_link_libraries(utest2 ${PROJECT_NAME})
 
 # enable cv_bridge python tests
 find_package(ament_cmake_pytest REQUIRED)


### PR DESCRIPTION
This PR separates the tests into different files so they can be run individually (and this is what most ros2 libraries do), and also links against the library and not the individual dependencies.

I'm not too sure if removing ``APPEND_LIBRARY_DIRS`` is going to break the tests on windows or not...