### PR TITLE
silence dperecation warnings using boost macros

### DIFF
--- a/cv_bridge/src/module.hpp
+++ b/cv_bridge/src/module.hpp
@@ -17,7 +17,19 @@
 #define CV_BRIDGE_MODULE_HPP_
 
 #include <iostream>
+
+// Have to define macros to silence warnings about deprecated headers being used by
+// boost/python.hpp in some versions of boost.
+// See: https://github.com/ros-perception/vision_opencv/issues/449
+#include <boost/version.hpp>
+#if (BOOST_VERSION / 100 >= 1073 && BOOST_VERSION / 100 <= 1076)  // Boost 1.73 - 1.76
+  #define BOOST_BIND_GLOBAL_PLACEHOLDERS
+#endif
+#if (BOOST_VERSION / 100 == 1074)  // Boost 1.74
+  #define BOOST_ALLOW_DEPRECATED_HEADERS
+#endif
 #include <boost/python.hpp>
+
 #include <cv_bridge/cv_bridge.hpp>
 #include <Python.h>
 


### PR DESCRIPTION
Resolves: #449

As I explained in https://github.com/ros-perception/vision_opencv/issues/449#issuecomment-1243072420,

> `#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.` this deprecation was added in 1.73 and was fixed in 1.77 by [boostorg/python#315](https://github.com/boostorg/python/pull/315).
> 
> `#pragma message: This header is deprecated. Use <iterator> instead.` this deprecation was added in 1.74 and was fixed in 1.75 by [boostorg/python#308](https://github.com/boostorg/python/pull/308).
> 
> Depending on the boost version, we could add preprocessor macros to disable the warnings.