### PR TITLE
export rclcpp as dependency

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -75,6 +75,7 @@ endif()
 ament_export_dependencies(
   OpenCV
   sensor_msgs
+  rclcpp
 )
 
 ament_export_targets(export_${PROJECT_NAME})


### PR DESCRIPTION
In https://github.com/ros-perception/vision_opencv/pull/441, a #include to an rclcpp file was added to a header file, but cv_bridge wasn't exporting it correctly for downstream packages. This causes problems as described in #490.

Resolves: #490