### PR TITLE
Add new CMake option CV_BRIDGE_ENABLE_PYTHON

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -12,7 +12,13 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra)
 endif()
 
+option(CV_BRIDGE_DISABLE_PYTHON "Disable building Python bindings" OFF)
+
 if(ANDROID)
+  set(CV_BRIDGE_DISABLE_PYTHON ON)
+endif()
+
+if(CV_BRIDGE_DISABLE_PYTHON)
   find_package(Boost REQUIRED)
   set(boost_python_target "")
 else()
@@ -54,7 +60,7 @@ if(NOT OpenCV_FOUND)
   )
 endif()
 
-if(NOT ANDROID)
+if(NOT CV_BRIDGE_DISABLE_PYTHON)
   ament_python_install_package(${PROJECT_NAME}
     PACKAGE_DIR python/${PROJECT_NAME}
   )

--- a/cv_bridge/src/CMakeLists.txt
+++ b/cv_bridge/src/CMakeLists.txt
@@ -31,7 +31,7 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}_export.h
   DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME})
 
-if(NOT ANDROID)
+if(NOT CV_BRIDGE_DISABLE_PYTHON)
   Python3_add_library(${PROJECT_NAME}_boost MODULE module.cpp module_opencv4.cpp)
   target_link_libraries(${PROJECT_NAME}_boost PRIVATE
     ${PROJECT_NAME}


### PR DESCRIPTION
To disable building the `cv_bridge` Python support package if desired.