### PR TITLE
Address RHEL buildfailure with Boost 1.66.0

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT ANDROID)
       # Resolution for newer versions:
       #  https://gitlab.kitware.com/cmake/cmake/issues/16391
       set(_Boost_PYTHON3_HEADERS "boost/python.hpp")
-      find_package(Boost REQUIRED python)
+      find_package(Boost REQUIRED python3)
     else()
       string(REPLACE "." ";" VERSION_LIST ${PYTHONLIBS_VERSION_STRING})
       list(GET VERSION_LIST 0 PYTHONLIBS_VERSION_MAJOR)

--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -18,7 +18,8 @@ if(NOT ANDROID)
     find_package(Boost REQUIRED python)
   else()
     find_package(Boost QUIET)
-    if(Boost_VERSION LESS 106700)
+    message(STATUS "Boost_VERSION_STRING: " ${Boost_VERSION_STRING})
+    if(Boost_VERSION_STRING VERSION_LESS "1.67")
       # This is a bit of a hack to suppress a warning
       #   No header defined for python3; skipping header check
       # Which should only affect Boost versions < 1.67


### PR DESCRIPTION
Fixes a problem introduced in https://github.com/ros-perception/vision_opencv/pull/489/files, when boost version is 1.66 (ie. on RHEL).

``python3`` should be the correct component used from Boost, not ``python``.