### PR TITLE
Ensure dynamic scaling works when given matrix with inf and -inf values.

### DIFF
--- a/cv_bridge/src/cv_bridge.cpp
+++ b/cv_bridge/src/cv_bridge.cpp
@@ -649,7 +649,9 @@ CvImageConstPtr cvtColorForDisplay(
 
   // Perform scaling if asked for
   if (options.do_dynamic_scaling) {
-    cv::minMaxLoc(source->image, &min_image_value, &max_image_value);
+    float inf = std::numeric_limits<float>::infinity();
+    cv::Mat mask = ((source->image!=inf) & (source->image!=-inf));
+    cv::minMaxLoc(source->image, &min_image_value, &max_image_value, NULL, NULL, mask);
     if (min_image_value == max_image_value) {
       CvImagePtr result(new CvImage());
       result->header = source->header;

--- a/cv_bridge/test/CMakeLists.txt
+++ b/cv_bridge/test/CMakeLists.txt
@@ -18,6 +18,7 @@ ament_add_gtest(${PROJECT_NAME}-utest
   test_compression.cpp
   utest.cpp utest2.cpp
   test_rgb_colors.cpp
+  test_dynamic_scaling.cpp
   APPEND_LIBRARY_DIRS "${cv_bridge_lib_dir}")
 target_link_libraries(${PROJECT_NAME}-utest
   ${PROJECT_NAME}

--- a/cv_bridge/test/test_dynamic_scaling.cpp
+++ b/cv_bridge/test/test_dynamic_scaling.cpp
@@ -1,0 +1,38 @@
+#include <cv_bridge/cv_bridge.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+#include <gtest/gtest.h>
+#include <cmath>
+
+TEST(TestDynamicScaling, ignoreInfAndNanValues)
+{
+  float inf = std::numeric_limits<float>::infinity();
+  float nan = std::numeric_limits<float>::quiet_NaN();
+  std::vector<float> data{50, 100, 150, -inf, inf, nan};
+  std::string encoding = sensor_msgs::image_encodings::TYPE_32FC1;
+
+  sensor_msgs::msg::Image msg;
+  msg.height = 1;
+  msg.width = data.size();
+  msg.encoding = encoding;
+  msg.step = data.size() * 4;
+  for (auto d : data) {
+    uint8_t * p = reinterpret_cast<uint8_t *>(&d);
+    for (std::size_t i = 0; i != sizeof(float); ++i) {
+      msg.data.push_back(p[i]);
+    }
+  }
+
+  cv_bridge::CvtColorForDisplayOptions options;
+  options.do_dynamic_scaling = true;
+
+  cv_bridge::CvImageConstPtr img = cv_bridge::toCvCopy(msg);
+  auto converted = cv_bridge::cvtColorForDisplay(img, "", options);
+
+  // Check that the scaling works for non-inf and non-nan values.
+  std::vector<uint8_t> expected = {0, 0, 0, 128, 128, 128, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  for (unsigned i = 0; i < expected.size(); ++i)
+  {
+    EXPECT_EQ(converted->image.at<uint8_t>(i), expected.at(i));
+  }
+}


### PR DESCRIPTION
[REP-117](https://www.ros.org/reps/rep-0117.html) mentions that inf and -inf are valid values in depth images. However, dynamic_scaling doesn't currently work when such values are in the image as the cv::minMaxLoc method doesn't expect inf and -inf values (it's fine with nan values).

By using a mask, we can ignore inf and non inf values when calling ``cv::minMaxLoc``.

Resolves: #450

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>