### PR TITLE
Allow users to override encoding string in ROSCvMatContainer

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -3,9 +3,9 @@ project(cv_bridge)
 
 find_package(ament_cmake_ros REQUIRED)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/cv_bridge/src/cv_mat_sensor_msgs_image_type_adapter.cpp
+++ b/cv_bridge/src/cv_mat_sensor_msgs_image_type_adapter.cpp
@@ -177,7 +177,6 @@ void
 ROSCvMatContainer::get_sensor_msgs_msg_image_copy(
   sensor_msgs::msg::Image & sensor_msgs_image) const
 {
-  // TODO(YV): call convert_to_ros_message() instead?
   sensor_msgs_image.height = frame_.rows;
   sensor_msgs_image.width = frame_.cols;
   if (encoding_override_.has_value() && !encoding_override_.value().empty())
@@ -201,7 +200,7 @@ ROSCvMatContainer::get_sensor_msgs_msg_image_copy(
         break;
       default:
         throw std::runtime_error("unsupported encoding type");
-    }    
+    }
   }
   sensor_msgs_image.step = static_cast<sensor_msgs::msg::Image::_step_type>(frame_.step);
   size_t size = frame_.step * frame_.rows;


### PR DESCRIPTION
Fixes #504 

The implementation here relies on using an `std::optional<std::string> encoding_override` argument which can be supplied during instantiation of `ROSCVMatContainer`. If provided, the value will be used, else default to the existing behavior of inferring the encoding from `cv::Mat::type()`.
In order to use `std::optional`, I also had to bump the C++ version to C++17.

Also it looks like `ROSCvMatContainer::get_sensor_msgs_msg_image_copy()` has duplicate code from `convert_to_ros_message()`. I've left a TODO to explore reusing the latter within this function. Happy to implement it if the change is acceptable.

Signed-off-by: Yadunund <yadunund@openrobotics.org>