### PR TITLE
Changed to make provision for using OpenCV 4

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -13,7 +13,15 @@ if(NOT ANDROID)
 else()
 find_package(Boost REQUIRED)
 endif()
-find_package(OpenCV 3 REQUIRED
+
+set(_opencv_version 4)
+find_package(OpenCV 4 QUIET)
+if(NOT OpenCV_FOUND)
+  message(STATUS "Did not find OpenCV 4, trying OpenCV 3")
+  set(_opencv_version 3)
+endif()
+
+find_package(OpenCV ${_opencv_version} REQUIRED
   COMPONENTS
     opencv_core
     opencv_imgproc


### PR DESCRIPTION
The compiler will check for OpenCV 4 in the system before defaulting to OpenCV 3.
Have also made a few changes in module_opencv2.cpp to cv::Mat.refcount object, since it was removed in OpenCV 3. Passed a separate integer pointer to manage refcount.

Solves #508 