### PR TITLE
Fix build errors in Ubuntu Lunar when fetched directly

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -66,7 +66,13 @@ if(NOT CV_BRIDGE_DISABLE_PYTHON)
   )
 endif()
 
+# add library
+add_library(${PROJECT_NAME})
 add_subdirectory(src)
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
 
 # cv_bridge_lib_dir is passed as APPEND_LIBRARY_DIRS for each ament_add_gtest call so
 # the project library that they link against is on the library path.
@@ -87,7 +93,7 @@ ament_export_dependencies(
 ament_export_targets(export_${PROJECT_NAME})
 
 # install the include folder
-install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
+install(DIRECTORY include/ DESTINATION include)
 
 install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION bin

--- a/cv_bridge/src/CMakeLists.txt
+++ b/cv_bridge/src/CMakeLists.txt
@@ -1,15 +1,14 @@
-# add library
-add_library(${PROJECT_NAME}
+target_sources(${PROJECT_NAME} PRIVATE 
   cv_bridge.cpp
   cv_mat_sensor_msgs_image_type_adapter.cpp
   rgb_colors.cpp
 )
 include(GenerateExportHeader)
 generate_export_header(${PROJECT_NAME} EXPORT_FILE_NAME ${PROJECT_NAME}/${PROJECT_NAME}_export.h)
-target_include_directories(${PROJECT_NAME} PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>"
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
-  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+)
 target_link_libraries(${PROJECT_NAME} PUBLIC
   ${sensor_msgs_TARGETS}
   opencv_core
@@ -25,11 +24,12 @@ install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
 )
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}_export.h
-  DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME})
+  DESTINATION include/${PROJECT_NAME})
 
 if(NOT CV_BRIDGE_DISABLE_PYTHON)
   Python3_add_library(${PROJECT_NAME}_boost MODULE module.cpp module_opencv4.cpp)


### PR DESCRIPTION
I had some build/include errors when building in Ubuntu Lunar (23.04) when compiling nav2 from source. 

I've modified the CMakelists to make use of the target_sources command.
The library is now a level higher.
The commands to target_include_directories are properly scoped depending on the directory, especially for the generated export header. No more traversing up directories and back down. 

Relates to https://github.com/ros-perception/vision_opencv/pull/419