### PR TITLE
Fixed conversion for 32FC1

### DIFF
--- a/cv_bridge/src/cv_bridge.cpp
+++ b/cv_bridge/src/cv_bridge.cpp
@@ -599,7 +599,8 @@ CvImageConstPtr cvtColorForDisplay(
       } else {
         // We choose BGR by default here as we assume people will use OpenCV
         if ((enc::bitDepth(source->encoding) == 8) ||
-          (enc::bitDepth(source->encoding) == 16))
+          (enc::bitDepth(source->encoding) == 16) || 
+          (enc::bitDepth(source->encoding) == 32))
         {
           encoding = enc::BGR8;
         } else {


### PR DESCRIPTION
I was trying to visualize a 32FC1 with `image_view` but the conversion was failing, this fix should at least show the image instead of a black image.