### PR TITLE
decode images in mode IMREAD_UNCHANGED

### DIFF
--- a/cv_bridge/python/cv_bridge/core.py
+++ b/cv_bridge/python/cv_bridge/core.py
@@ -130,7 +130,7 @@ class CvBridge(object):
         str_msg = cmprs_img_msg.data
         buf = np.ndarray(shape=(1, len(str_msg)),
                          dtype=np.uint8, buffer=cmprs_img_msg.data)
-        im = cv2.imdecode(buf, cv2.IMREAD_ANYCOLOR)
+        im = cv2.imdecode(buf, cv2.IMREAD_UNCHANGED)
 
         if desired_encoding == 'passthrough':
             return im


### PR DESCRIPTION
This is a backport of https://github.com/ros-perception/vision_opencv/pull/228 to ROS 2.

You can use the same conversion script in that PR to test that without this PR the data that is converted from the original 16bit image becomes an 8bit image where the values do not match anymore:
```
original: 2500 uint16
converted: 9 uint8
match? False
```
and with this PR, the conversion is done correctly and the values match:
```
original: 2500 uint16
converted: 2500 uint16
match? True
```
