### PR TITLE
add opencv_include_dirs in include

### DIFF
--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(OpenCV REQUIRED)
 
 catkin_package(CATKIN_DEPENDS sensor_msgs
                DEPENDS OpenCV
-               INCLUDE_DIRS include
+               INCLUDE_DIRS include ${OpenCV_INCLUDE_DIRS}
                LIBRARIES ${PROJECT_NAME}
 )
 


### PR DESCRIPTION
because we use `opencv` in include files, we need to set `OpenCV_INCLUDE_DIRS` in `INCLUDE_DIRS`.
https://github.com/ros-perception/vision_opencv/blob/a34a0c261984e4ab71f267d093f6a48820801d80/image_geometry/include/image_geometry/pinhole_camera_model.hpp#L7-L9