### PR TITLE
Add Windows Compatibility Fixes for vision_opencv Build

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -12,6 +12,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra)
 endif()
 
+add_compile_options(-DHAVE_SNPRINTF)
+
 if(ANDROID)
   find_package(Boost REQUIRED)
   set(boost_python_target "")

--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -12,8 +12,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra)
 endif()
 
-add_compile_options(-DHAVE_SNPRINTF)
-
 if(ANDROID)
   find_package(Boost REQUIRED)
   set(boost_python_target "")
@@ -92,7 +90,3 @@ install(TARGETS ${PROJECT_NAME}
 ament_package(
   CONFIG_EXTRAS "cmake/cv_bridge-extras.cmake.in"
 )
-
-if (MSVC)
-    target_compile_definitions(${PROJECT_NAME}_boost PRIVATE -DBOOST_PYTHON_STATIC_LIB)
-endif()

--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -90,3 +90,7 @@ install(TARGETS ${PROJECT_NAME}
 ament_package(
   CONFIG_EXTRAS "cmake/cv_bridge-extras.cmake.in"
 )
+
+if (MSVC)
+    target_compile_definitions(${PROJECT_NAME}_boost PRIVATE -DBOOST_PYTHON_STATIC_LIB)
+endif()

--- a/cv_bridge/src/CMakeLists.txt
+++ b/cv_bridge/src/CMakeLists.txt
@@ -33,6 +33,10 @@ if(NOT ANDROID)
     Python3::NumPy)
   target_compile_definitions(${PROJECT_NAME}_boost PRIVATE PYTHON3)
 
+  if (MSVC)
+    target_compile_definitions(${PROJECT_NAME}_boost PRIVATE -DBOOST_PYTHON_STATIC_LIB -DHAVE_SNPRINTF)
+  endif()
+
   if(OpenCV_VERSION_MAJOR VERSION_EQUAL 4)
     target_compile_definitions(${PROJECT_NAME}_boost PRIVATE OPENCV_VERSION_4)
   endif()


### PR DESCRIPTION
### Summary

This PR adds compatibility improvements to enable successful building of `vision_opencv` on Windows by introducing additional compiler options. 

### Changes Made

1. **Added Compiler Definitions for Windows Compatibility**:
   - Added `-DHAVE_SNPRINTF` to `add_compile_options` to ensure that the `snprintf` function is available during compilation. This is a common requirement when building cross-platform code on Windows.

2. **Boost Python Library Static Linking on Windows**:
   - For MSVC (Microsoft Visual C++), `target_compile_definitions` was updated with `-DBOOST_PYTHON_STATIC_LIB`. This option helps to statically link the Boost Python library, which is necessary for compatibility on Windows.

### Rationale

These changes are specifically intended as a workaround to address issues encountered when building `vision_opencv` on Windows. By adding the `snprintf` definition and setting Boost Python for static linking, this PR aims to resolve common build issues related to cross-platform support.

### Additional Notes

- This PR only affects Windows builds and should not impact Linux-based systems.
- These adjustments were tested on Windows using MSVC, and the build completed successfully after these changes.

Resolves: #401