### PR TITLE
Improve Boost Python component detection for CMake-based Boost installs

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -34,8 +34,16 @@ else()
     find_package(Boost REQUIRED COMPONENTS python3)
     set(boost_python_target "Boost::python3")
   else()
-    find_package(Boost REQUIRED COMPONENTS python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR})
-    set(boost_python_target "Boost::python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
+    # Try versioned Python component first
+    find_package(Boost QUIET COMPONENTS python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR})
+
+    if(NOT Boost_python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}_FOUND)
+      # Fallback to generic python component
+      find_package(Boost REQUIRED COMPONENTS python)
+      set(boost_python_target "Boost::python")
+    else()
+      set(boost_python_target "Boost::python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
This PR improves the CMake logic used to locate Boost.Python in `cv_bridge`.

Recent Boost versions (e.g. 1.89) built with **CMake** no longer generate
versioned CMake package config files for Python components such as:

```bash
boost_python311-config.cmake
```
Instead, the only available package config file is the generic component:
```bash
boost_python-config.cmake
```
This causes the current logic:

```cmake
    find_package(Boost REQUIRED COMPONENTS python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR})
    set(boost_python_target "Boost::python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
```

to fail even though the library file libboost_python311.* exists.

## Cause

CMake-built Boost installs:

- `libboost_python<pyver>.*`
- a generic CMake target: `Boost::python`

But **does not** install:

- `Boost::python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}`
- `boost_python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}-config.cmake`

As a result, CMake cannot resolve the requested versioned component, and the
configuration step fails even though the underlying library file exists.


## CMake Side FIx

Use versioned Boost.Python components when available, and automatically fall back to the generic `python` component when they are not.  
This makes the CMake logic compatible with both CMake-built and Autotools-built Boost installations.
