### PR TITLE
Boost failure repro CI

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -17,6 +17,7 @@ option(CV_BRIDGE_DISABLE_PYTHON "Disable building Python bindings" OFF)
 if(ANDROID)
   set(CV_BRIDGE_DISABLE_PYTHON ON)
 endif()
+# TODO (rmc)
 
 if(CV_BRIDGE_DISABLE_PYTHON)
   find_package(Boost REQUIRED)


### PR DESCRIPTION
In #558 CI was complaining about boost but, I think it is unlikely that the changes would cause those errors. So made this to just run a job with no changes.

Update:
Seems to a ci.ros2.org problem. It seems to be working on build.ros2.org