### PR TITLE
Enable compliance with -Wshadow by renaming variables.

### DIFF
--- a/cv_bridge/include/cv_bridge/cv_bridge.hpp
+++ b/cv_bridge/include/cv_bridge/cv_bridge.hpp
@@ -98,9 +98,9 @@ public:
    * \brief Constructor.
    */
   CvImage(
-    const std_msgs::msg::Header & header, const std::string & encoding,
-    const cv::Mat & image = cv::Mat())
-  : header(header), encoding(encoding), image(image)
+    const std_msgs::msg::Header & header_, const std::string & encoding_,
+    const cv::Mat & image_ = cv::Mat())
+  : header(header_), encoding(encoding_), image(image_)
   {
   }
 

--- a/cv_bridge/src/cv_bridge.cpp
+++ b/cv_bridge/src/cv_bridge.cpp
@@ -514,10 +514,10 @@ void CvImage::toCompressedImageMsg(
   const Format dst_format) const
 {
   ros_image.header = header;
-  cv::Mat image;
+  cv::Mat image_to_encode;
   if (encoding == enc::BGR8 || encoding == enc::BGRA8  || encoding == enc::MONO8 || encoding == enc::MONO16)
   {
-    image = this->image;
+    image_to_encode = this->image;
   } else {
     CvImagePtr tempThis = std::make_shared<CvImage>(*this);
     CvImagePtr temp;
@@ -526,12 +526,12 @@ void CvImage::toCompressedImageMsg(
     } else {
       temp = cvtColor(tempThis, enc::BGR8);
     }
-    image = temp->image;
+    image_to_encode = temp->image;
   }
 
   std::string format = getFormat(dst_format);
   ros_image.format = format;
-  cv::imencode("." + format, image, ros_image.data);
+  cv::imencode("." + format, image_to_encode, ros_image.data);
 }
 
 // Deep copy data, returnee is mutable


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A|
| Primary OS tested on | Ubuntu |
| Is this a breaking change? | No |
---

## Description of the problem

* When including the `<cv_bridge/cv_bridge.hpp>` header, explicit ignores for shadowing had to be passed in order to build with `-Wshadow`:

   ```cpp
  #pragma GCC diagnostic push
  #pragma GCC diagnostic ignored "-Wshadow"
  #include <cv_bridge/cv_bridge.hpp>
  #pragma GCC diagnostic pop
  ```

* This can be explicitly checked by building the package on its own:

  ```bash
  $ colcon build --packages-select cv_bridge --cmake-args -DCMAKE_CXX_FLAGS="-Wshadow -Werror=shadow"
  Starting >>> cv_bridge
  --- stderr: cv_bridge                             
  In file included from /autonomy_ws/src/vision_opencv/cv_bridge/src/cv_bridge.cpp:37:
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp: In constructor ‘cv_bridge::CvImage::CvImage(const std_msgs::msg::Header&, const std::string&, const cv::Mat&)’:
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:102:21: error: declaration of ‘image’ shadows a member of ‘cv_bridge::CvImage’ [-Werror=shadow]
    102 |     const cv::Mat & image = cv::Mat())
        |     ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:90:11: note: shadowed declaration is here
     90 |   cv::Mat image;           // !< Image data for use with OpenCV
        |           ^~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:101:63: error: declaration of ‘encoding’ shadows a member of ‘cv_bridge::CvImage’ [-Werror=shadow]
    101 |     const std_msgs::msg::Header & header, const std::string & encoding,
        |                                           ~~~~~~~~~~~~~~~~~~~~^~~~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:89:15: note: shadowed declaration is here
     89 |   std::string encoding;    // !< Image encoding ("mono8", "bgr8", etc.)
        |               ^~~~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:101:35: error: declaration of ‘header’ shadows a member of ‘cv_bridge::CvImage’ [-Werror=shadow]
    101 |     const std_msgs::msg::Header & header, const std::string & encoding,
        |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:88:25: note: shadowed declaration is here
     88 |   std_msgs::msg::Header header;  // !< ROS header
        |                         ^~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp: In constructor ‘cv_bridge::CvImage::CvImage(const std_msgs::msg::Header&, const std::string&, const cv::Mat&)’:
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:102:21: error: declaration of ‘image’ shadows a member of ‘cv_bridge::CvImage’ [-Werror=shadow]
    102 |     const cv::Mat & image = cv::Mat())
        |     ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:90:11: note: shadowed declaration is here
     90 |   cv::Mat image;           // !< Image data for use with OpenCV
        |           ^~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:101:63: error: declaration of ‘encoding’ shadows a member of ‘cv_bridge::CvImage’ [-Werror=shadow]
    101 |     const std_msgs::msg::Header & header, const std::string & encoding,
        |                                           ~~~~~~~~~~~~~~~~~~~~^~~~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:89:15: note: shadowed declaration is here
     89 |   std::string encoding;    // !< Image encoding ("mono8", "bgr8", etc.)
        |               ^~~~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:101:35: error: declaration of ‘header’ shadows a member of ‘cv_bridge::CvImage’ [-Werror=shadow]
    101 |     const std_msgs::msg::Header & header, const std::string & encoding,
        |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:88:25: note: shadowed declaration is here
     88 |   std_msgs::msg::Header header;  // !< ROS header
        |                         ^~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp: In constructor ‘cv_bridge::CvImage::CvImage(const std_msgs::msg::Header&, const std::string&, const cv::Mat&)’:
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:102:21: error: declaration of ‘image’ shadows a member of ‘cv_bridge::CvImage’ [-Werror=shadow]
    102 |     const cv::Mat & image = cv::Mat())
        |     ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:90:11: note: shadowed declaration is here
     90 |   cv::Mat image;           // !< Image data for use with OpenCV
        |           ^~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:101:63: error: declaration of ‘encoding’ shadows a member of ‘cv_bridge::CvImage’ [-Werror=shadow]
    101 |     const std_msgs::msg::Header & header, const std::string & encoding,
        |                                           ~~~~~~~~~~~~~~~~~~~~^~~~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:89:15: note: shadowed declaration is here
     89 |   std::string encoding;    // !< Image encoding ("mono8", "bgr8", etc.)
        |               ^~~~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:101:35: error: declaration of ‘header’ shadows a member of ‘cv_bridge::CvImage’ [-Werror=shadow]
    101 |     const std_msgs::msg::Header & header, const std::string & encoding,
        |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:88:25: note: shadowed declaration is here
     88 |   std_msgs::msg::Header header;  // !< ROS header
        |                         ^~~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/cv_bridge.cpp: In member function ‘void cv_bridge::CvImage::toCompressedImageMsg(sensor_msgs::msg::CompressedImage&, cv_bridge::Format) const’:
  /autonomy_ws/src/vision_opencv/cv_bridge/src/cv_bridge.cpp:517:11: error: declaration of ‘image’ shadows a member of ‘cv_bridge::CvImage’ [-Werror=shadow]
    517 |   cv::Mat image;
        |           ^~~~~
  /autonomy_ws/src/vision_opencv/cv_bridge/src/../include/cv_bridge/cv_bridge.hpp:90:11: note: shadowed declaration is here
     90 |   cv::Mat image;           // !< Image data for use with OpenCV
        |           ^~~~~
  cc1plus: some warnings being treated as errors
  gmake[2]: *** [src/CMakeFiles/cv_bridge.dir/build.make:76: src/CMakeFiles/cv_bridge.dir/cv_bridge.cpp.o] Error 1
  gmake[1]: *** [CMakeFiles/Makefile2:245: src/CMakeFiles/cv_bridge.dir/all] Error 2
  gmake: *** [Makefile:146: all] Error 2
  ---
  Failed   <<< cv_bridge [2.21s, exited with code 2]
  ```

## Resolution and Testing

* After renaming some of the variables to be devoid of shadowing faults, the build and test now pass cleanly:

  ```bash
  colcon build --packages-select cv_bridge --cmake-args -DCMAKE_CXX_FLAGS="-Wshadow -Werror=shadow" && colcon test --packages-select cv_bridge
  ```