### PR TITLE
cv_bridge: suppress CMP0167 warning from find_package(Boost)

### DIFF
--- a/cv_bridge/CMakeLists.txt
+++ b/cv_bridge/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.14)
 project(cv_bridge)
 
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
+
 find_package(ament_cmake_ros REQUIRED)
 
 # Default to C++17


### PR DESCRIPTION
cv_bridge CMakeLists.txt calls find_package(Boost) twice -- once to check the version (QUIET) and once with COMPONENTS to link python. In CMake 3.30+, this triggers a CMP0167 warning because both FindBoost.cmake (module mode) and BoostConfig.cmake (config mode) exist.

Set CMP0167 to NEW before any find_package(Boost) calls to suppress the warning. Guarded with if(POLICY CMP0167) so older CMake versions are unaffected.

Fixes #567.